### PR TITLE
style cleanups

### DIFF
--- a/GGDBFetch/ggdbfetch/__init__.py
+++ b/GGDBFetch/ggdbfetch/__init__.py
@@ -1,4 +1,3 @@
-CLUSTERS_DB = 'complete_clusters.db'
-SAMPLE2PROTEIN_DB = 'sample2protein.db'
-SAMPLE2PATH = 'sample2path.tsv'
-
+CLUSTERS_DB = "complete_clusters.db"
+SAMPLE2PROTEIN_DB = "sample2protein.db"
+SAMPLE2PATH = "sample2path.tsv"

--- a/GGDBFetch/ggdbfetch/clusters.py
+++ b/GGDBFetch/ggdbfetch/clusters.py
@@ -23,4 +23,3 @@ def get_clusters(p30_id, dbpath):
     con.close()
 
     return p100s, p100_to_p90, p100_to_p30
-

--- a/GGDBFetch/ggdbfetch/clusters.py
+++ b/GGDBFetch/ggdbfetch/clusters.py
@@ -1,6 +1,7 @@
-from ggdbfetch import CLUSTERS_DB
-from os.path import join
 import sqlite3
+from os.path import join
+
+from ggdbfetch import CLUSTERS_DB
 
 
 def get_clusters(p30_id, dbpath):

--- a/GGDBFetch/ggdbfetch/main.py
+++ b/GGDBFetch/ggdbfetch/main.py
@@ -1,8 +1,10 @@
-import click
 import os
-from ggdbfetch.retrieve import _targets_and_baits
 import shutil
 import sys
+
+import click
+from ggdbfetch.retrieve import _targets_and_baits
+
 
 @click.group()
 def cli():

--- a/GGDBFetch/ggdbfetch/main.py
+++ b/GGDBFetch/ggdbfetch/main.py
@@ -11,16 +11,18 @@ def cli():
     """A command line tool to fetch ggdb data"""
     pass
 
-@cli.group(short_help='Retrieve stuff.')
+
+@cli.group(short_help="Retrieve stuff.")
 def retrieve():
     pass
 
-@retrieve.command(short_help='Retrieve by target and baits.')
-@click.argument('infile')
-@click.option('--outdir', '-o', default='ggdbfetch_output')
-@click.option('--dbpath', default='/home/mdurrant/GeneGraphDB/data/rep_genomes')
-@click.option('--force/--no-force', default=False)
-@click.option('--threads', '-t', default=1)
+
+@retrieve.command(short_help="Retrieve by target and baits.")
+@click.argument("infile")
+@click.option("--outdir", "-o", default="ggdbfetch_output")
+@click.option("--dbpath", default="/home/mdurrant/GeneGraphDB/data/rep_genomes")
+@click.option("--force/--no-force", default=False)
+@click.option("--threads", "-t", default=1)
 def targets_and_baits(infile, outdir, dbpath, force, threads):
 
     if os.path.isdir(outdir) and not force:
@@ -32,5 +34,3 @@ def targets_and_baits(infile, outdir, dbpath, force, threads):
 
     os.makedirs(outdir)
     _targets_and_baits(infile, dbpath, outdir, threads)
-
-

--- a/GGDBFetch/ggdbfetch/misc.py
+++ b/GGDBFetch/ggdbfetch/misc.py
@@ -1,15 +1,14 @@
-
 def revcomp(s):
-    o = ''
+    o = ""
     for c in s[::-1]:
-        if c == 'A':
-            o += 'T'
-        elif c == 'T':
-            o += 'A'
-        elif c == 'C':
-            o += 'G'
-        elif c == 'G':
-            o += 'C'
+        if c == "A":
+            o += "T"
+        elif c == "T":
+            o += "A"
+        elif c == "C":
+            o += "G"
+        elif c == "G":
+            o += "C"
         else:
             o += c
     return o

--- a/GGDBFetch/ggdbfetch/regions.py
+++ b/GGDBFetch/ggdbfetch/regions.py
@@ -1,8 +1,10 @@
+import sqlite3
+from os.path import basename, join
+
+import pandas as pd
 from ggdbfetch import misc
 from pyfastx import Fasta
-from os.path import basename, join
-import sqlite3
-import pandas as pd
+
 
 def get_regions(sample_path, p100s, p100_to_p90, p100_to_p30, dbpath):
 

--- a/GGDBFetch/ggdbfetch/regions.py
+++ b/GGDBFetch/ggdbfetch/regions.py
@@ -9,19 +9,25 @@ from pyfastx import Fasta
 def get_regions(sample_path, p100s, p100_to_p90, p100_to_p30, dbpath):
 
     sample = basename(sample_path)
-    out_fna = join(dbpath, sample_path, sample + '.fna.gz')
-    out_coords = join(dbpath, sample_path, sample+'.gene_coords.db')
-    out_contigs = join(dbpath, sample_path, sample + '.contigs.db')
+    out_fna = join(dbpath, sample_path, sample + ".fna.gz")
+    out_coords = join(dbpath, sample_path, sample + ".gene_coords.db")
+    out_contigs = join(dbpath, sample_path, sample + ".contigs.db")
     coords = get_gene_coords(sample, out_coords, out_contigs, p100s, p100_to_p90, p100_to_p30)
     contig_range_seqs = dict()
     ranges = coords[
-        ['target_p100', 'contig', 'contig_id', 'contig_start', 'contig_end', 'target_orient']].drop_duplicates()
+        ["target_p100", "contig", "contig_id", "contig_start", "contig_end", "target_orient"]
+    ].drop_duplicates()
     for target_p100, contig, contig_id, contig_start, contig_end, target_orient in zip(
-            ranges.target_p100, ranges.contig, ranges.contig_id, ranges.contig_start, ranges.contig_end, ranges.target_orient
+        ranges.target_p100,
+        ranges.contig,
+        ranges.contig_id,
+        ranges.contig_start,
+        ranges.contig_end,
+        ranges.target_orient,
     ):
         contig_seq = get_contig_seq(out_fna, contig, (contig_start, contig_end), target_orient)
-        if 'O' in contig_seq or 'o' in contig_seq:
-            print(sample, contig_id, contig_seq, sep='\t')
+        if "O" in contig_seq or "o" in contig_seq:
+            print(sample, contig_id, contig_seq, sep="\t")
         contig_range_seqs[contig_id] = contig_seq
 
     return contig_range_seqs, coords
@@ -33,10 +39,10 @@ def flip_coords(coords, contig_range):
     for p100, start, end, orient in coords:
         start = contig_length - start + 1
         end = contig_length - end + 1
-        if orient == '+':
-            orient = '-'
-        elif orient == '-':
-            orient = '+'
+        if orient == "+":
+            orient = "-"
+        elif orient == "-":
+            orient = "+"
         out_coords.append([p100, end, start, orient])
     return out_coords
 
@@ -50,14 +56,16 @@ def get_contig_range(start, end, contig_length):
 
     return cstart, cend
 
+
 def get_contig_seq(fna, contig, contig_range, orient):
     fasta = Fasta(fna)
-    seq = str(fasta[contig][contig_range[0]:contig_range[1]]).upper()
+    seq = str(fasta[contig][contig_range[0] : contig_range[1]]).upper()
 
-    if orient == '-':
+    if orient == "-":
         seq = misc.revcomp(seq)
 
     return seq
+
 
 def get_gene_coords(sample, gene_coords, contigs_db, p100s, p100_to_p90, p100_to_p30):
 
@@ -68,9 +76,9 @@ def get_gene_coords(sample, gene_coords, contigs_db, p100s, p100_to_p90, p100_to
     p100_coords = set()
     for p100 in p100s:
         cmd = "SELECT p100,contig,start,end,orient FROM coords WHERE p100='{}'".format(p100)
-        for p100,contig,start,end,orient in cur.execute(cmd):
+        for p100, contig, start, end, orient in cur.execute(cmd):
             contigs.add(contig)
-            p100_coords.add((p100,contig,start,end,orient))
+            p100_coords.add((p100, contig, start, end, orient))
     cur.close()
     con.close()
 
@@ -89,23 +97,53 @@ def get_gene_coords(sample, gene_coords, contigs_db, p100s, p100_to_p90, p100_to
     all_coords = []
     for p100, contig, start, end, orient in p100_coords:
         contig_range = get_contig_range(start, end, contig_lengths[contig])
-        cmd =  'SELECT p100,start,end,orient FROM coords WHERE contig="{c}" AND start >= {s} AND end <= {e}'.format(c=contig, s=contig_range[0], e=contig_range[1])
+        cmd = 'SELECT p100,start,end,orient FROM coords WHERE contig="{c}" AND start >= {s} AND end <= {e}'.format(
+            c=contig, s=contig_range[0], e=contig_range[1]
+        )
         for this_p100, this_start, this_end, this_strand in cur.execute(cmd):
             this_start -= contig_range[0]
             this_end -= contig_range[0]
             coords = [this_p100, this_start, this_end, this_strand]
-            if orient == '-':
+            if orient == "-":
                 coords = flip_coords([coords], contig_range)[0]
-            contig_id = p100_to_p30[p100]+'|'+p100_to_p90[p100]+'|'+p100+'|'+sample+'|'+contig+':'+str(contig_range[0])+'-'+str(contig_range[1])
-            if orient == '+':
-                contig_id += '(FWD)'
+            contig_id = (
+                p100_to_p30[p100]
+                + "|"
+                + p100_to_p90[p100]
+                + "|"
+                + p100
+                + "|"
+                + sample
+                + "|"
+                + contig
+                + ":"
+                + str(contig_range[0])
+                + "-"
+                + str(contig_range[1])
+            )
+            if orient == "+":
+                contig_id += "(FWD)"
             else:
-                contig_id += '(REV)'
-            all_coords.append(coords + [p100, orient, contig, contig_id, contig_range[0], contig_range[1], contig_lengths[contig]])
+                contig_id += "(REV)"
+            all_coords.append(
+                coords + [p100, orient, contig, contig_id, contig_range[0], contig_range[1], contig_lengths[contig]]
+            )
     cur.close()
     conn.close()
 
     coords = pd.DataFrame(all_coords)
-    coords.columns = ['p100', 'start', 'end', 'strand', 'target_p100', 'target_orient', 'contig', 'contig_id', 'contig_start', 'contig_end', 'contig_length']
+    coords.columns = [
+        "p100",
+        "start",
+        "end",
+        "strand",
+        "target_p100",
+        "target_orient",
+        "contig",
+        "contig_id",
+        "contig_start",
+        "contig_end",
+        "contig_length",
+    ]
 
     return coords

--- a/GGDBFetch/ggdbfetch/retrieve.py
+++ b/GGDBFetch/ggdbfetch/retrieve.py
@@ -14,39 +14,39 @@ def _targets_and_baits(infile, dbpath, outdir, threads):
             sample, spath = line.strip().split()
             sample2path[sample] = spath
 
-
     with open(infile) as inf:
         for line in inf:
-            target_id, bait_ids = line.strip().split('\t')
+            target_id, bait_ids = line.strip().split("\t")
             print("Working on", target_id)
             retrieve_target_and_bait(target_id, bait_ids, dbpath, sample2path, outdir, threads)
 
+
 def retrieve_target_and_bait(target_id, bait_ids, dbpath, sample2path, outdir, threads):
 
-    print('\tGetting clusters...')
+    print("\tGetting clusters...")
     all_p100, p100_to_p90, p100_to_p30 = clusters.get_clusters(target_id, dbpath)
-    print('\tGetting samples for {} p100s...'.format(len(all_p100)))
+    print("\tGetting samples for {} p100s...".format(len(all_p100)))
     sample2p100s = sample2protein.get_sample_to_p100s(all_p100, dbpath)
 
-    print('\tGetting regions...')
+    print("\tGetting regions...")
     args = [(sample2path[samp], sample2p100s[samp], p100_to_p90, p100_to_p30, dbpath) for samp in sample2p100s]
     with Pool(threads) as pool:
         results = pool.starmap(regions.get_regions, args)
 
-    out_gff = open(join(outdir, target_id + '.examples.gff'), 'w')
+    out_gff = open(join(outdir, target_id + ".examples.gff"), "w")
     for contigs, coords in results:
         for p100, start, end, strand, target_p100, contig in zip(
-                coords.p100, coords.start, coords.end, coords.strand, coords.target_p100, coords.contig_id
+            coords.p100, coords.start, coords.end, coords.strand, coords.target_p100, coords.contig_id
         ):
             seqname, source, feature, score, frame = contig, "PRODIGAL", "CDS", 1, 0
             if p100 == target_p100:
-                feature = 'CDS_target'
+                feature = "CDS_target"
             elif p100 in bait_ids:
-                feature = 'CDS_bait'
-            attrib = 'ID=' + p100
+                feature = "CDS_bait"
+            attrib = "ID=" + p100
             out = [seqname, source, feature, start, end, score, strand, frame, attrib]
-            print(*out, sep='\t', file=out_gff)
+            print(*out, sep="\t", file=out_gff)
     for contigs, coords in results:
         for contig in contigs:
-            print('>' + contig, contigs[contig], sep='\n', file=out_gff)
+            print(">" + contig, contigs[contig], sep="\n", file=out_gff)
     out_gff.close()

--- a/GGDBFetch/ggdbfetch/retrieve.py
+++ b/GGDBFetch/ggdbfetch/retrieve.py
@@ -1,7 +1,9 @@
-from ggdbfetch import clusters, sample2protein, regions
-from ggdbfetch import SAMPLE2PATH
-from os.path import join
 from multiprocessing import Pool
+from os.path import join
+
+from ggdbfetch import SAMPLE2PATH
+from ggdbfetch import clusters, regions, sample2protein
+
 
 def _targets_and_baits(infile, dbpath, outdir, threads):
 

--- a/GGDBFetch/ggdbfetch/sample2protein.py
+++ b/GGDBFetch/ggdbfetch/sample2protein.py
@@ -20,4 +20,3 @@ def get_sample_to_p100s(p100s, dbpath):
     con.close()
 
     return dict(sample2p100s)
-

--- a/GGDBFetch/ggdbfetch/sample2protein.py
+++ b/GGDBFetch/ggdbfetch/sample2protein.py
@@ -1,8 +1,10 @@
-from ggdbfetch import SAMPLE2PROTEIN_DB
-from os.path import join
 import sqlite3
 from collections import defaultdict
+from os.path import join
+
+from ggdbfetch import SAMPLE2PROTEIN_DB
 from tqdm import tqdm
+
 
 def get_sample_to_p100s(p100s, dbpath):
     con = sqlite3.connect(join(dbpath, SAMPLE2PROTEIN_DB))

--- a/GGDBFetch/setup.py
+++ b/GGDBFetch/setup.py
@@ -2,24 +2,15 @@ from setuptools import find_packages, setup
 
 setup(
     name="ggdbfetch",
-    version='0.0.0_dev',
-    description='A command line to retrieve contigs from GGDB.',
-    url='https://github.com/pdhsulab/GeneGraphDB/GGDBFetch',
+    version="0.0.0_dev",
+    description="A command line to retrieve contigs from GGDB.",
+    url="https://github.com/pdhsulab/GeneGraphDB/GGDBFetch",
     author="Matt Durrant",
     author_email="mdurrant@berkeley.edu",
     license="MIT",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=[
-        'click==8.0.1',
-        'pyfastx',
-        'pandas'
-        'tqdm'
-    ],
+    install_requires=["click==8.0.1", "pyfastx", "pandas" "tqdm"],
     zip_safe=False,
-    entry_points = {
-        'console_scripts': [
-            'ggdbf = ggdbfetch.main:cli'
-        ]
-}
+    entry_points={"console_scripts": ["ggdbf = ggdbfetch.main:cli"]},
 )

--- a/GGDBFetch/setup.py
+++ b/GGDBFetch/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="ggdbfetch",

--- a/genegraphdb/_load.py
+++ b/genegraphdb/_load.py
@@ -11,13 +11,15 @@ from genegraphdb import proteinnode
 from genegraphdb import testing
 
 
-def _single(sample_id, google_bucket, distance, comment, outfilename, samples_path = '', clean_files=False):
+def _single(sample_id, google_bucket, distance, comment, outfilename, samples_path="", clean_files=False):
     outfile = open(outfilename, "a")
     try:
         sample_id_path = sample_id + "/"
-        fasta, protein, contigs = samples_path + sample_id_path + sample_id + ".fna.gz", \
-                                  samples_path + sample_id_path + sample_id + ".prodigal.faa.gz", \
-                                  samples_path + sample_id_path + sample_id + ".contigs.tsv.gz"
+        fasta, protein, contigs = (
+            samples_path + sample_id_path + sample_id + ".fna.gz",
+            samples_path + sample_id_path + sample_id + ".prodigal.faa.gz",
+            samples_path + sample_id_path + sample_id + ".contigs.tsv.gz",
+        )
         tic = time.time()
         sorted_gff_name = crisprnode.merge_gff(sample_id, samples_path)
         load_proteins(sample_id, protein, samples_path)
@@ -37,59 +39,59 @@ def _single(sample_id, google_bucket, distance, comment, outfilename, samples_pa
         testing.log_errors_multi_loadneo4j(samples_path, sample_id, e)
     outfile.close()
 
-def load_proteins(sample_id, protein, samples_path = ''):
+
+def load_proteins(sample_id, protein, samples_path=""):
     print("Loading proteins...")
     tic = time.time()
     outfile = open(samples_path + sample_id + "/proteins.tmp.csv", "w")
     print("hashid,length", file=outfile)
 
     done = set()
-    handle = gzip.open(protein, 'rt')
-    for rec in SeqIO.parse(handle, 'fasta'):
+    handle = gzip.open(protein, "rt")
+    for rec in SeqIO.parse(handle, "fasta"):
         name_truncate = rec.id[:18]
         if name_truncate in done:
-                continue
+            continue
         done.add(name_truncate)
-        length = len(str(rec.seq.strip('*')))
-        print(name_truncate+","+str(length), file=outfile)
+        length = len(str(rec.seq.strip("*")))
+        print(name_truncate + "," + str(length), file=outfile)
     outfile.close()
     del done
 
     conn = graphdb.Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
     cmd = "LOAD CSV WITH HEADERS FROM 'file:///{csv}' AS row MERGE (n:Protein {{hashid: row.hashid, length:row.length}})".format(
-        csv=abspath(samples_path + sample_id + '/proteins.tmp.csv')
+        csv=abspath(samples_path + sample_id + "/proteins.tmp.csv")
     )
     print(cmd)
     conn.query(cmd, db=DBNAME)
     conn.close()
     toc = time.time()
-    #remove(sample_id + '/proteins.tmp.csv')
-    print("Loading proteins took %f seconds" % (toc-tic))
+    # remove(sample_id + '/proteins.tmp.csv')
+    print("Loading proteins took %f seconds" % (toc - tic))
 
 
-
-def load_fasta(sample_id, fasta, contigs, samples_path = ''):
+def load_fasta(sample_id, fasta, contigs, samples_path=""):
     print("Loading contigs...")
     tic = time.time()
     recid2contig = dict()
-    with gzip.open(contigs, 'rt') as infile:
+    with gzip.open(contigs, "rt") as infile:
         infile.readline()
         for line in infile:
-            line = line.strip().split('\t')
+            line = line.strip().split("\t")
             recid2contig[line[0]] = (line[1], int(line[3]))
 
     outfile = open(samples_path + sample_id + "/contigs.tmp.csv", "w")
     print("hashid,length", file=outfile)
     done = set()
-    handle = gzip.open(fasta, 'rt')
-    for rec in SeqIO.parse(handle, 'fasta'):
+    handle = gzip.open(fasta, "rt")
+    for rec in SeqIO.parse(handle, "fasta"):
         contig, clength = recid2contig[rec.id]
         name_truncate = contig[:18]
         if name_truncate in done:
             continue
         done.add(name_truncate)
-        length = len(str(rec.seq.strip('*')))
-        print(name_truncate+","+str(clength), file=outfile)
+        length = len(str(rec.seq.strip("*")))
+        print(name_truncate + "," + str(clength), file=outfile)
     outfile.close()
     del done
 
@@ -97,40 +99,43 @@ def load_fasta(sample_id, fasta, contigs, samples_path = ''):
     cmd = """LOAD CSV WITH HEADERS FROM 'file:///{csv}' AS row
           MERGE (n:Contig {{hashid: row.hashid, length:row.length}})
           """.format(
-        csv=abspath(samples_path + sample_id + '/contigs.tmp.csv')
+        csv=abspath(samples_path + sample_id + "/contigs.tmp.csv")
     )
     print(cmd)
     conn.query(cmd, db=DBNAME)
     conn.close()
     toc = time.time()
 
-    print("Loading contigs took %f seconds" % (toc-tic))
+    print("Loading contigs took %f seconds" % (toc - tic))
     # remove(sample_id + '/contigs.tmp.csv')
 
     return recid2contig
 
-def load_contig2sample(sample_id, contigs, samples_path = ''):
+
+def load_contig2sample(sample_id, contigs, samples_path=""):
     print("Loading contig2sample edges...")
     tic = time.time()
     outfile = open(samples_path + sample_id + "/contig2sample.tmp.csv", "w")
     print("chash,sampleid", file=outfile)
-    with gzip.open(contigs, 'rt') as infile:
+    with gzip.open(contigs, "rt") as infile:
         infile.readline()
         for line in infile:
-            line = line.strip().split('\t')
-            print(line[1][:18]+','+str(sample_id), file=outfile)
+            line = line.strip().split("\t")
+            print(line[1][:18] + "," + str(sample_id), file=outfile)
     outfile.close()
     conn = graphdb.Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
     cmd_make_node = """
                    MERGE (s:Sample {{sampleID: "{id}"}})
-                    """.format(id=str(sample_id))
+                    """.format(
+        id=str(sample_id)
+    )
     cmd_load_edges = """
           LOAD CSV WITH HEADERS FROM 'file:///{csv}' AS row 
           MATCH (c:Contig), (s:Sample)
           WHERE c.hashid = row.chash AND s.sampleID = row.sampleid
           MERGE (c)-[e:contig2sample]->(s)
           """.format(
-        csv=abspath(samples_path + sample_id + '/contig2sample.tmp.csv')
+        csv=abspath(samples_path + sample_id + "/contig2sample.tmp.csv")
     )
     print(cmd_make_node)
     conn.query(cmd_make_node, db=DBNAME)
@@ -139,39 +144,41 @@ def load_contig2sample(sample_id, contigs, samples_path = ''):
     conn.close()
     toc = time.time()
 
-    print("Loading contig2sample edges took %f seconds" % (toc-tic))
+    print("Loading contig2sample edges took %f seconds" % (toc - tic))
 
-    #remove("contig2sample.tmp.csv")
+    # remove("contig2sample.tmp.csv")
 
-def load_coords(sample_id, gff, recid2contig, crisprid2crhash, samples_path = ''):
+
+def load_coords(sample_id, gff, recid2contig, crisprid2crhash, samples_path=""):
     print("Loading gene and crispr coords...")
     tic = time.time()
-    with open(samples_path + sample_id + "/gene_coords.tmp.csv", "w") as g_out, \
-            open(samples_path + sample_id + "/crispr_coords.tmp.csv", "w") as cr_out:
+    with open(samples_path + sample_id + "/gene_coords.tmp.csv", "w") as g_out, open(
+        samples_path + sample_id + "/crispr_coords.tmp.csv", "w"
+    ) as cr_out:
         print("recid,phash,chash,start,end,orient", file=g_out)
         print("recid,crhash,chash,start,end", file=cr_out)
         with open(gff, "rt") as infile:
             for line in infile:
                 if line.startswith("#"):
                     continue
-                line = line.strip().split('\t')
+                line = line.strip().split("\t")
                 if len(line) != 9:
                     print(len(line))
                     continue
                 if "Prodigal" in line[1]:
-                    phash = line[-1].split("ID=")[-1].split(';')[0][:18]
+                    phash = line[-1].split("ID=")[-1].split(";")[0][:18]
                     chash = recid2contig[line[0]][0][:18]
-                    print(line[0], phash, chash, line[3], line[4], line[6], sep=',', file=g_out)
+                    print(line[0], phash, chash, line[3], line[4], line[6], sep=",", file=g_out)
                 elif "minced" in line[1]:
-                    old_id = line[-1].split("ID=")[-1].split(';')[0][:18]
+                    old_id = line[-1].split("ID=")[-1].split(";")[0][:18]
                     crhash = crisprid2crhash[old_id]
                     chash = recid2contig[line[0]][0][:18]
-                    print(line[0], crhash, chash, line[3], line[4], sep=',', file=cr_out)
+                    print(line[0], crhash, chash, line[3], line[4], sep=",", file=cr_out)
     crisprnode.load_crispr_coords(sample_id, samples_path)
     proteinnode.load_protein_coords(sample_id, samples_path)
     toc = time.time()
 
-    print("Loading gene and crispr coords took %f seconds" % (toc-tic))
+    print("Loading gene and crispr coords took %f seconds" % (toc - tic))
 
-    #remove("gene_coords.tmp.csv")
-    #remove("crispr_coords.tmp.csv")
+    # remove("gene_coords.tmp.csv")
+    # remove("crispr_coords.tmp.csv")

--- a/genegraphdb/_load.py
+++ b/genegraphdb/_load.py
@@ -1,16 +1,15 @@
-from genegraphdb import * 
+import gzip
+import time
+from os.path import abspath
+
+from Bio import SeqIO
+
+from genegraphdb import *
+from genegraphdb import crisprnode
 from genegraphdb import graphdb
 from genegraphdb import proteinnode
-from genegraphdb import crisprnode
 from genegraphdb import testing
-from Bio import SeqIO
-import gzip
-import re
-import sys
-import os
-from os import remove
-from os.path import abspath
-import time
+
 
 def _single(sample_id, google_bucket, distance, comment, outfilename, samples_path = '', clean_files=False):
     outfile = open(outfilename, "a")

--- a/genegraphdb/_loadsql.py
+++ b/genegraphdb/_loadsql.py
@@ -1,20 +1,15 @@
-from genegraphdb import *
-from genegraphdb import graphdb
-from genegraphdb import proteinnode
-from genegraphdb import proteinnodesql
-from genegraphdb import crisprnode
-from genegraphdb import crisprnodesql
-from genegraphdb import testing
-from Bio import SeqIO
-import gzip
-import re
-import sys
 import csv
-import os
-from os import remove
-from os.path import abspath
-import time
+import gzip
 import sqlite3
+import time
+
+from Bio import SeqIO
+
+from genegraphdb import crisprnodesql
+from genegraphdb import proteinnodesql
+from genegraphdb import proteinnodesql
+from genegraphdb import testing
+
 
 def _single(sample_id, google_bucket, distance, comment, outfilename, samples_path = '', clean_files=False):
     outfile = open(outfilename, "a")

--- a/genegraphdb/_loadsql.py
+++ b/genegraphdb/_loadsql.py
@@ -11,13 +11,15 @@ from genegraphdb import proteinnodesql
 from genegraphdb import testing
 
 
-def _single(sample_id, google_bucket, distance, comment, outfilename, samples_path = '', clean_files=False):
+def _single(sample_id, google_bucket, distance, comment, outfilename, samples_path="", clean_files=False):
     outfile = open(outfilename, "a")
     try:
         sample_id_path = sample_id + "/"
-        fasta, protein, contigs = samples_path + sample_id_path + sample_id + ".fna.gz", \
-                                  samples_path + sample_id_path + sample_id + ".prodigal.faa.gz", \
-                                  samples_path + sample_id_path + sample_id + ".contigs.tsv.gz"
+        fasta, protein, contigs = (
+            samples_path + sample_id_path + sample_id + ".fna.gz",
+            samples_path + sample_id_path + sample_id + ".prodigal.faa.gz",
+            samples_path + sample_id_path + sample_id + ".contigs.tsv.gz",
+        )
         tic = time.time()
         sorted_gff_name = crisprnodesql.merge_gff(sample_id, samples_path)
         load_proteins(sample_id, protein, samples_path)
@@ -37,148 +39,155 @@ def _single(sample_id, google_bucket, distance, comment, outfilename, samples_pa
         testing.log_errors_multisql_loadsql(samples_path, sample_id, e)
     outfile.close()
 
-def load_proteins(sample_id, protein, samples_path = ''):
+
+def load_proteins(sample_id, protein, samples_path=""):
     print("Loading proteins...")
     tic = time.time()
     outfile = open(samples_path + sample_id + "/proteins.tmp.sql.csv", "w")
     print("hashid,length", file=outfile)
 
     done = set()
-    handle = gzip.open(protein, 'rt')
-    for rec in SeqIO.parse(handle, 'fasta'):
+    handle = gzip.open(protein, "rt")
+    for rec in SeqIO.parse(handle, "fasta"):
         name_truncate = rec.id[:18]
         if name_truncate in done:
-                continue
+            continue
         done.add(name_truncate)
-        length = len(str(rec.seq.strip('*')))
-        print(name_truncate+","+str(length), file=outfile)
+        length = len(str(rec.seq.strip("*")))
+        print(name_truncate + "," + str(length), file=outfile)
     outfile.close()
     del done
 
-    con = sqlite3.connect('genegraph.db')
+    con = sqlite3.connect("genegraph.db")
     cur = con.cursor()
-    protein_csv_path = samples_path + sample_id + '/proteins.tmp.sql.csv'
+    protein_csv_path = samples_path + sample_id + "/proteins.tmp.sql.csv"
     protein_csv = open(protein_csv_path)
     rows = csv.reader(protein_csv)
     next(rows)
-    cmd = '''
+    cmd = """
     INSERT OR IGNORE INTO proteins (hashid, length) VALUES (?,?)
-    '''
+    """
     cur.executemany(cmd, rows)
     con.commit()
     con.close()
 
     toc = time.time()
-    #remove(samples_path + sample_id + '/proteins.tmp.sql.csv')
-    print("Loading proteins took %f seconds" % (toc-tic))
+    # remove(samples_path + sample_id + '/proteins.tmp.sql.csv')
+    print("Loading proteins took %f seconds" % (toc - tic))
 
-def load_fasta(sample_id, fasta, contigs, samples_path = ''):
+
+def load_fasta(sample_id, fasta, contigs, samples_path=""):
     print("Loading contigs...")
     tic = time.time()
     recid2contig = dict()
-    with gzip.open(contigs, 'rt') as infile:
+    with gzip.open(contigs, "rt") as infile:
         infile.readline()
         for line in infile:
-            line = line.strip().split('\t')
+            line = line.strip().split("\t")
             recid2contig[line[0]] = (line[1], int(line[3]))
 
     outfile = open(samples_path + sample_id + "/contigs.tmp.sql.csv", "w")
     print("hashid,length", file=outfile)
     done = set()
-    handle = gzip.open(fasta, 'rt')
-    for rec in SeqIO.parse(handle, 'fasta'):
+    handle = gzip.open(fasta, "rt")
+    for rec in SeqIO.parse(handle, "fasta"):
         contig, clength = recid2contig[rec.id]
         name_truncate = contig[:18]
         if name_truncate in done:
             continue
         done.add(name_truncate)
-        length = len(str(rec.seq.strip('*')))
-        print(name_truncate+","+str(clength), file=outfile)
+        length = len(str(rec.seq.strip("*")))
+        print(name_truncate + "," + str(clength), file=outfile)
     outfile.close()
     del done
 
-    con = sqlite3.connect('genegraph.db')
+    con = sqlite3.connect("genegraph.db")
     con.execute("PRAGMA journal_mode=WAL")
     cur = con.cursor()
-    contig_csv_path = samples_path + sample_id + '/contigs.tmp.sql.csv'
+    contig_csv_path = samples_path + sample_id + "/contigs.tmp.sql.csv"
     contig_csv = open(contig_csv_path)
     rows = csv.reader(contig_csv)
     next(rows)
-    cmd = '''
+    cmd = """
     INSERT OR IGNORE INTO contigs (hashid, length) VALUES (?,?)
-    '''
+    """
     cur.executemany(cmd, rows)
     con.commit()
     con.close()
     toc = time.time()
 
-    print("Loading contigs took %f seconds" % (toc-tic))
+    print("Loading contigs took %f seconds" % (toc - tic))
     # remove(samples_path + sample_id + '/contigs.tmp.sql.csv')
 
     return recid2contig
 
-def load_contig2sample(sample_id, contigs, samples_path = ''):
+
+def load_contig2sample(sample_id, contigs, samples_path=""):
     print("Loading contig2sample edges...")
     tic = time.time()
     outfile = open(samples_path + sample_id + "/contig2sample.tmp.sql.csv", "w")
     print("chash,sampleid", file=outfile)
-    with gzip.open(contigs, 'rt') as infile:
+    with gzip.open(contigs, "rt") as infile:
         infile.readline()
         for line in infile:
-            line = line.strip().split('\t')
-            print(line[1][:18]+','+str(sample_id), file=outfile)
+            line = line.strip().split("\t")
+            print(line[1][:18] + "," + str(sample_id), file=outfile)
     outfile.close()
-    con = sqlite3.connect('genegraph.db')
+    con = sqlite3.connect("genegraph.db")
     cur = con.cursor()
-    contig2sample_csv_path = samples_path + sample_id + '/contig2sample.tmp.sql.csv'
+    contig2sample_csv_path = samples_path + sample_id + "/contig2sample.tmp.sql.csv"
     contig2sample_csv = open(contig2sample_csv_path)
     rows = csv.reader(contig2sample_csv)
     next(rows)
     cur.execute("PRAGMA journal_mode=WAL")
-    cmd = '''
+    cmd = """
     INSERT OR IGNORE INTO contig2sample (contighashid, sampleid) VALUES (?,?)
-    '''
+    """
     cur.executemany(cmd, rows)
-    cmd2 = '''
+    cmd2 = """
     INSERT OR IGNORE INTO samples (sampleid) VALUES ("{}")
-    '''.format(sample_id)
+    """.format(
+        sample_id
+    )
     cur.execute(cmd2)
 
     con.commit()
     con.close()
     toc = time.time()
 
-    print("Loading contig2sample edges took %f seconds" % (toc-tic))
+    print("Loading contig2sample edges took %f seconds" % (toc - tic))
 
-    #remove(samples_path + sample_id + "/contig2sample.tmp.csv")
+    # remove(samples_path + sample_id + "/contig2sample.tmp.csv")
 
-def load_coords(sample_id, gff, recid2contig, crisprid2crhash, samples_path = ''):
+
+def load_coords(sample_id, gff, recid2contig, crisprid2crhash, samples_path=""):
     print("Loading gene and crispr coords...")
     tic = time.time()
-    with open(samples_path + sample_id + "/gene_coords.tmp.sql.csv", "w") as g_out, \
-            open(samples_path + sample_id + "/crispr_coords.tmp.sql.csv", "w") as cr_out:
+    with open(samples_path + sample_id + "/gene_coords.tmp.sql.csv", "w") as g_out, open(
+        samples_path + sample_id + "/crispr_coords.tmp.sql.csv", "w"
+    ) as cr_out:
         print("recid,phash,chash,start,end,orient", file=g_out)
         print("recid,crhash,chash,start,end", file=cr_out)
         with open(gff, "rt") as infile:
             for line in infile:
                 if line.startswith("#"):
                     continue
-                line = line.strip().split('\t')
+                line = line.strip().split("\t")
                 if len(line) != 9:
                     print(len(line))
                     continue
                 if "Prodigal" in line[1]:
-                    phash = line[-1].split("ID=")[-1].split(';')[0][:18]
+                    phash = line[-1].split("ID=")[-1].split(";")[0][:18]
                     chash = recid2contig[line[0]][0][:18]
-                    print(line[0], phash, chash, line[3], line[4], line[6], sep=',', file=g_out)
+                    print(line[0], phash, chash, line[3], line[4], line[6], sep=",", file=g_out)
                 elif "minced" in line[1]:
-                    old_id = line[-1].split("ID=")[-1].split(';')[0][:18]
+                    old_id = line[-1].split("ID=")[-1].split(";")[0][:18]
                     crhash = crisprid2crhash[old_id]
                     chash = recid2contig[line[0]][0][:18]
-                    print(line[0], crhash, chash, line[3], line[4], sep=',', file=cr_out)
+                    print(line[0], crhash, chash, line[3], line[4], sep=",", file=cr_out)
     crisprnodesql.load_crispr_coords(sample_id, samples_path)
     # To do - debug this. why does gene_coords have a repeat? How can I get SQL to skip vs error out
     proteinnodesql.load_protein_coords(sample_id, samples_path)
     toc = time.time()
 
-    print("Loading gene and crispr coords took %f seconds" % (toc-tic))
+    print("Loading gene and crispr coords took %f seconds" % (toc - tic))

--- a/genegraphdb/clusternode.py
+++ b/genegraphdb/clusternode.py
@@ -1,18 +1,9 @@
+import time
+from os.path import abspath
+
 from genegraphdb import *
 from genegraphdb import graphdb
-from genegraphdb import _load
-from genegraphdb import testing
-from Bio import SeqIO
-import gzip
-import re
-import sys
-import os
-from os import remove
-from os.path import abspath
-import time
-from collections import deque
-import csv
-from csv import reader
+
 
 def load_cluster_nodes():
     print("Loading cluster nodes...")

--- a/genegraphdb/clusternode.py
+++ b/genegraphdb/clusternode.py
@@ -46,4 +46,4 @@ def load_cluster_nodes():
 
     conn.close()
     toc = time.time()
-    print("Loading cluster nodes took %f seconds" % (toc-tic))
+    print("Loading cluster nodes took %f seconds" % (toc - tic))

--- a/genegraphdb/crisprnode.py
+++ b/genegraphdb/crisprnode.py
@@ -1,17 +1,12 @@
+import hashlib
+import os
+import re
+import time
+from os.path import abspath
+
 from genegraphdb import *
 from genegraphdb import graphdb
-from genegraphdb import _load
-from Bio import SeqIO
-import gzip
-import re
-import sys
-import os
-from os import remove
-from os.path import abspath
-import hashlib
-import time
-from collections import deque, ChainMap
-from csv import reader
+
 
 def merge_gff(sample_id, samples_path):
     # parse through minced.gff

--- a/genegraphdb/crisprnodesql.py
+++ b/genegraphdb/crisprnodesql.py
@@ -1,20 +1,9 @@
-from genegraphdb import *
-from genegraphdb import graphdb
-from genegraphdb import _load
-from genegraphdb import _loadsql
-from Bio import SeqIO
-import gzip
-import re
-import sys
-import os
-from os import remove
-from os.path import abspath
 import hashlib
-import time
-from collections import deque, ChainMap
-import csv
-from csv import reader
+import os
+import re
 import sqlite3
+import time
+
 
 def merge_gff(sample_id, samples_path):
     # parse through minced.gff

--- a/genegraphdb/dl_test_data.py
+++ b/genegraphdb/dl_test_data.py
@@ -1,16 +1,5 @@
-from genegraphdb import *
-from genegraphdb import graphdb
-from genegraphdb import _load
-from genegraphdb import testing
-from Bio import SeqIO
-import gzip
-import re
-import sys
 import os
-from os import remove
-from os.path import abspath
-import time
-from collections import deque
+
 
 def create_dir(dir_name):
     os.system("mkdir " + dir_name)

--- a/genegraphdb/dl_test_data.py
+++ b/genegraphdb/dl_test_data.py
@@ -4,6 +4,7 @@ import os
 def create_dir(dir_name):
     os.system("mkdir " + dir_name)
 
+
 def download_dir(bucket_dir):
     bucket_path = "gs://jluo_bucket/" + bucket_dir
     command = "gsutil cp -m " + bucket_path + " ."

--- a/genegraphdb/graphdb.py
+++ b/genegraphdb/graphdb.py
@@ -6,7 +6,6 @@ from genegraphdb import *
 
 
 class Neo4jConnection:
-
     def __init__(self, uri, user, pwd):
         self.__uri = uri
         self.__user = user
@@ -35,16 +34,19 @@ class Neo4jConnection:
                 session.close()
         return response
 
+
 def showdatabases():
     conn = Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
     return conn.query("SHOW DATABASES")
     conn.close()
 
+
 def hasdb():
     for rec in showdatabases():
-        if rec['name'] == DBNAME:
+        if rec["name"] == DBNAME:
             return True
     return False
+
 
 def createdb():
     print("Creating database: %s" % DBNAME)
@@ -54,21 +56,23 @@ def createdb():
     conn.query("CREATE CONSTRAINT uniq_protein_hashid ON (n:Protein) ASSERT n.hashid IS UNIQUE", db=DBNAME)
     # ENTERPRISE ONLY: conn.query("CREATE CONSTRAINT exist_protein_hashid ON (n:Protein) ASSERT exists(n.hashid)", db=DBNAME)
     conn.query("CREATE CONSTRAINT uniq_contig_hashid ON (n:Contig) ASSERT n.hashid IS UNIQUE", db=DBNAME)
-     # ENTERPRISE ONLY: conn.query("CREATE CONSTRAINT exist_contig_hashid ON (n:Contig) ASSERT exists(n.hashid)", db=DBNAME)
+    # ENTERPRISE ONLY: conn.query("CREATE CONSTRAINT exist_contig_hashid ON (n:Contig) ASSERT exists(n.hashid)", db=DBNAME)
     conn.close()
 
     print("Database created")
 
+
 def num_nodes():
     conn = Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
-    num_nodes = conn.query("MATCH (n) RETURN count(*)", db=DBNAME)[0]['count(*)']
+    num_nodes = conn.query("MATCH (n) RETURN count(*)", db=DBNAME)[0]["count(*)"]
     conn.close()
 
     return num_nodes
 
+
 def num_rels():
     conn = Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
-    num_rels = conn.query("MATCH ()-[r]->() RETURN count(r) as count", db=DBNAME)[0]['count']
+    num_rels = conn.query("MATCH ()-[r]->() RETURN count(r) as count", db=DBNAME)[0]["count"]
     conn.close()
 
     return num_rels
@@ -83,7 +87,7 @@ def add_node(nodetype, properties=None, conn=None):
 
     if properties is not None:
         cmd = "CREATE (n:{ntype} {props})".format(ntype=nodetype, props=str(properties))
-        cmd = re.sub(r"'([^':]+)':", r'\1:', cmd)
+        cmd = re.sub(r"'([^':]+)':", r"\1:", cmd)
     else:
         cmd = "CREATE (n:{ntype} )".format(ntype=nodetype)
 
@@ -91,6 +95,7 @@ def add_node(nodetype, properties=None, conn=None):
 
     if close:
         conn.close()
+
 
 def add_nodes(nodes, conn=None):
     close = False
@@ -105,6 +110,7 @@ def add_nodes(nodes, conn=None):
         conn.close()
     pass
 
+
 def protein_exists(hashid, conn=None):
 
     close = False
@@ -113,10 +119,9 @@ def protein_exists(hashid, conn=None):
         close = True
 
     cmd = "MATCH (n:Protein {hashid: '%s'}) return count(*) as count" % hashid
-    exists = conn.query(cmd, db=DBNAME)[0]['count'] > 0
+    exists = conn.query(cmd, db=DBNAME)[0]["count"] > 0
 
     if close:
         conn.close()
 
     return exists
-    

--- a/genegraphdb/graphdb.py
+++ b/genegraphdb/graphdb.py
@@ -1,11 +1,9 @@
-from genegraphdb import *
-from neo4j import GraphDatabase
-import time
 import re
-import hashlib
-from os.path import abspath
-from collections import defaultdict
-import uuid
+
+from neo4j import GraphDatabase
+
+from genegraphdb import *
+
 
 class Neo4jConnection:
 

--- a/genegraphdb/main.py
+++ b/genegraphdb/main.py
@@ -1,16 +1,16 @@
+import os
+from multiprocessing import Pool, cpu_count
+
 import click
+
 from genegraphdb import *
-from genegraphdb import graphdb
-from genegraphdb import sqldb
 from genegraphdb import _load
 from genegraphdb import _loadsql
+from genegraphdb import graphdb
+from genegraphdb import sqldb
 from genegraphdb import testing
-from genegraphdb import dl_test_data
-from genegraphdb import clusternode
 from genegraphdb import variables_global as vars_glob
-from multiprocessing import Pool, cpu_count
-from functools import partial
-import os
+
 
 @click.group()
 def cli():

--- a/genegraphdb/main.py
+++ b/genegraphdb/main.py
@@ -17,14 +17,16 @@ def cli():
     """A command line tool to create and query a gene graph databases."""
     pass
 
-@cli.command(short_help='Create a new Neo4j GeneGraphDB')
+
+@cli.command(short_help="Create a new Neo4j GeneGraphDB")
 def createdb():
     if not graphdb.hasdb():
         graphdb.createdb()
     else:
         print("Database %s already exists." % DBNAME)
 
-@cli.command(short_help='Get number of nodes and relationships in Neo4j GeneGraphDB')
+
+@cli.command(short_help="Get number of nodes and relationships in Neo4j GeneGraphDB")
 def dbinfo():
 
     if not graphdb.hasdb():
@@ -33,30 +35,34 @@ def dbinfo():
     print("Total nodes in database:", graphdb.num_nodes())
     print("Total relationships in database:", graphdb.num_rels())
 
-@cli.command(short_help='Create a new SQL GeneGraphDB')
+
+@cli.command(short_help="Create a new SQL GeneGraphDB")
 def createsqldb():
     if not sqldb.hasdb():
         sqldb.createdb()
     else:
         print("Database %s already exists." % DBNAME)
 
-@cli.command(short_help='Clear SQL GeneGraphDB')
+
+@cli.command(short_help="Clear SQL GeneGraphDB")
 def clearsqldb():
     if sqldb.hasdb():
         sqldb.cleardb()
     else:
         print("Database %s does not yet exist." % DBNAME)
 
-@cli.group(short_help='Load data into the graph database.')
+
+@cli.group(short_help="Load data into the graph database.")
 def load():
     pass
 
-@load.command(short_help='Load a single sample into the sql database.')
-@click.option('--sample-directory', '-s', required=True, help='Path to directory with sample immediately inside.')
-@click.option('--sample_id', '-id', required=True, type=str, help='The id of this genome or metagenomic sample.')
-@click.option('--google-bucket', '-gb', default=None, help='The Google bucket to store sequences.')
-@click.option('--distance', '-d', default=None, type=int, help='The distance in number of neighbors or base pairs')
-@click.option('--comment', '-c', default="", type=str, help='Any notes on a particular load script runtime')
+
+@load.command(short_help="Load a single sample into the sql database.")
+@click.option("--sample-directory", "-s", required=True, help="Path to directory with sample immediately inside.")
+@click.option("--sample_id", "-id", required=True, type=str, help="The id of this genome or metagenomic sample.")
+@click.option("--google-bucket", "-gb", default=None, help="The Google bucket to store sequences.")
+@click.option("--distance", "-d", default=None, type=int, help="The distance in number of neighbors or base pairs")
+@click.option("--comment", "-c", default="", type=str, help="Any notes on a particular load script runtime")
 def singlesql(sample_directory, sample_id, google_bucket, distance, comment):
     if distance is None:
         distance = 5000
@@ -64,18 +70,28 @@ def singlesql(sample_directory, sample_id, google_bucket, distance, comment):
     outfile = open("ggdb_load_stats.csv", "w")
     print("sample_id,load_time,p2p_edge_time,comment", file=outfile)
     outfile.close()
-    sample_path = sample_directory + sample_id + '/'
+    sample_path = sample_directory + sample_id + "/"
     outfilename = sample_path + "ggdb_load_stats.csv"
     _loadsql._single(sample_id, google_bucket, distance, comment, outfilename, sample_directory)
-    testing.get_runtime_summarystats(comment, infile_name=sample_path + "/ggdb_load_stats.sql.csv",
-                                     outfile_name=sample_path + "/ggdb_summary_stats.sql.csv")
+    testing.get_runtime_summarystats(
+        comment,
+        infile_name=sample_path + "/ggdb_load_stats.sql.csv",
+        outfile_name=sample_path + "/ggdb_summary_stats.sql.csv",
+    )
 
-@load.command(short_help='Load multiple samples into the sql database.')
-@click.option('--samples-directory', '-s', required=True, help='Path to samples directory. Inside is A001/B001/C001/sampleid/...')
-@click.option('--google-bucket', '-gb', default=None, help='The Google bucket to store sequences.')
-@click.option('--distance', '-d', default=None, type=int, help='The distance in number of neighbors or base pairs')
-@click.option('--comment', '-c', default="", type=str, help='Any notes on a particular load script runtime')
-@click.option('--clean_files/--show_temp_files', default=False, help='Remove all temp files generated when loading data into sql database')
+
+@load.command(short_help="Load multiple samples into the sql database.")
+@click.option(
+    "--samples-directory", "-s", required=True, help="Path to samples directory. Inside is A001/B001/C001/sampleid/..."
+)
+@click.option("--google-bucket", "-gb", default=None, help="The Google bucket to store sequences.")
+@click.option("--distance", "-d", default=None, type=int, help="The distance in number of neighbors or base pairs")
+@click.option("--comment", "-c", default="", type=str, help="Any notes on a particular load script runtime")
+@click.option(
+    "--clean_files/--show_temp_files",
+    default=False,
+    help="Remove all temp files generated when loading data into sql database",
+)
 def multisql(samples_directory, google_bucket, distance, comment, clean_files):
     if distance is None:
         distance = 5000
@@ -83,7 +99,7 @@ def multisql(samples_directory, google_bucket, distance, comment, clean_files):
     outfile = open("ggdb_load_stats.csv", "w")
     print("sample_id,load_time,p2p_edge_time,comment", file=outfile)
     outfile.close()
-    #outfilename = samples_path + "ggdb_load_stats.csv"
+    # outfilename = samples_path + "ggdb_load_stats.csv"
     outfilename = "ggdb_load_stats.csv"
 
     # loads samples one by one
@@ -108,7 +124,7 @@ def multisql(samples_directory, google_bucket, distance, comment, clean_files):
     # results = pool.starmap(_loadsql._single, loadsql_inputs)
     # pool.close()
     # pool.join()
-    
+
     # # load samples that errored out
     # sample_ids = []
     # for key in vars_glob.drep_samples_error.keys():
@@ -117,13 +133,15 @@ def multisql(samples_directory, google_bucket, distance, comment, clean_files):
     #     if os.path.isdir(samples_path):
     #         _loadsql._single(sampleid, google_bucket, distance, comment, outfilename, samples_path, clean_files)
 
-#_______________________
 
-@load.command(short_help='Load a single sample into the neo4j database.')
-@click.option('--sample_id', '-s', required=True, type=str, help='The id of this genome or metagenomic sample.')
-@click.option('--google-bucket', '-gb', default=None, help='The Google bucket to store sequences.')
-@click.option('--distance', '-d', default=None, type=int, help='The distance in number of neighbors or base pairs')
-@click.option('--comment', '-c', default="", type=str, help='Any notes on a particular load script runtime')
+# _______________________
+
+
+@load.command(short_help="Load a single sample into the neo4j database.")
+@click.option("--sample_id", "-s", required=True, type=str, help="The id of this genome or metagenomic sample.")
+@click.option("--google-bucket", "-gb", default=None, help="The Google bucket to store sequences.")
+@click.option("--distance", "-d", default=None, type=int, help="The distance in number of neighbors or base pairs")
+@click.option("--comment", "-c", default="", type=str, help="Any notes on a particular load script runtime")
 def single(sample_id, google_bucket, distance, comment):
     if distance is None:
         distance = 5000
@@ -131,16 +149,20 @@ def single(sample_id, google_bucket, distance, comment):
     print("sample_id,load_time,p2p_edge_time,comment", file=outfile)
     _load._single(sample_id, google_bucket, distance, comment, outfile)
     outfile.close()
-    testing.get_runtime_summarystats(comment, infile_name=sample_id + "/ggdb_load_stats.csv",
-                                     outfile_name=sample_id + "/ggdb_summary_stats.csv")
+    testing.get_runtime_summarystats(
+        comment, infile_name=sample_id + "/ggdb_load_stats.csv", outfile_name=sample_id + "/ggdb_summary_stats.csv"
+    )
 
-@load.command(short_help='Load multiple samples into the neo4j database.')
-@click.option('--google-bucket', '-gb', default=None, help='The Google bucket to store sequences.')
-@click.option('--distance', '-d', default=None, type=int, help='The distance in number of neighbors or base pairs')
-@click.option('--comment', '-c', default="", type=str, help='Any notes on a particular load script runtime')
-@click.option('--clean_files/--show_temp_files', default=False,
-              help='Remove all temp files generated when loading data into sql '
-                   'database')
+
+@load.command(short_help="Load multiple samples into the neo4j database.")
+@click.option("--google-bucket", "-gb", default=None, help="The Google bucket to store sequences.")
+@click.option("--distance", "-d", default=None, type=int, help="The distance in number of neighbors or base pairs")
+@click.option("--comment", "-c", default="", type=str, help="Any notes on a particular load script runtime")
+@click.option(
+    "--clean_files/--show_temp_files",
+    default=False,
+    help="Remove all temp files generated when loading data into sql " "database",
+)
 def multi(google_bucket, distance, comment, clean_files):
     if distance is None:
         distance = 5000
@@ -149,15 +171,13 @@ def multi(google_bucket, distance, comment, clean_files):
     outfile.close()
     outfilename = "ggdb_load_stats.csv"
 
-    
     # get sample ids and paths to samples. each sample directory contains input data (contigs.tsv, prodigal.faa, prodigal.gff, minced.gff, crisprcastyper.domains.tsv)
     load_inputs = []
     for key in vars_glob.drep_samples.keys():
         sampleid = key
         samples_path = vars_glob.drep_samples[key]
         if os.path.isdir(samples_path):
-            load_inputs.append(
-                (sampleid, google_bucket, distance, comment, outfilename, samples_path, clean_files))
+            load_inputs.append((sampleid, google_bucket, distance, comment, outfilename, samples_path, clean_files))
     # # Multiprocessing - has only been successfully tested locally. Neo4j server setup is slow on gcloud.
     pool = Pool(cpu_count())
     results = pool.starmap(_load._single, load_inputs)
@@ -166,26 +186,30 @@ def multi(google_bucket, distance, comment, clean_files):
     # testing.get_runtime_summarystats(comment)
     # clusternode.load_cluster_nodes()
 
-@cli.command(short_help='Ådd clusters to protein nodes in the database.')
+
+@cli.command(short_help="Ådd clusters to protein nodes in the database.")
 def addclusters():
     pass
 
-@cli.command(short_help='Get the association score for two gene clusters.')
-@click.argument('db')
-@click.argument('cluster1')
-@click.argument('cluster2')
+
+@cli.command(short_help="Get the association score for two gene clusters.")
+@click.argument("db")
+@click.argument("cluster1")
+@click.argument("cluster2")
 def association(db, cluster1, cluster2):
     pass
 
+
 # This is Sam's job
-@cli.command(short_help = 'Prepare database for queries')
+@cli.command(short_help="Prepare database for queries")
 def prepsearchdb():
     graphdb.kmerdb()
     pass
 
-@cli.command(short_help='Find close relatives of query protein seuqences')
-@click.argument('db')
-@click.argument('protein')
+
+@cli.command(short_help="Find close relatives of query protein seuqences")
+@click.argument("db")
+@click.argument("protein")
 def search(db, protein):
     graphdb.search(protein)
     pass

--- a/genegraphdb/proteinnode.py
+++ b/genegraphdb/proteinnode.py
@@ -8,22 +8,24 @@ from genegraphdb import *
 from genegraphdb import graphdb
 
 
-def connect_proteins_crisprs(sample_id, max_distance, samples_path = ''):
+def connect_proteins_crisprs(sample_id, max_distance, samples_path=""):
     sample_id_path = samples_path + sample_id + "/"
     print("Loading protein2protein edges...")
     tic = time.time()
     create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path)
-    load_csv(sample_id_path + "protein2protein.tmp.csv",
-             sample_id_path + "protein2crispr.tmp.csv",
-             sample_id_path + "protein2protein_window.tmp.csv",
-             sample_id_path + "protein2crispr_window.tmp.csv")
-
+    load_csv(
+        sample_id_path + "protein2protein.tmp.csv",
+        sample_id_path + "protein2crispr.tmp.csv",
+        sample_id_path + "protein2protein_window.tmp.csv",
+        sample_id_path + "protein2crispr_window.tmp.csv",
+    )
 
     toc = time.time()
     print("Loading protein2protein edges took %f seconds" % (toc - tic))
-    return toc-tic
+    return toc - tic
 
-def create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path = ''):
+
+def create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path=""):
     sample_id_path = samples_path + sample_id + "/"
     make_merged_coords_csv(sample_id, samples_path)
     outfile_prot_pair = open(sample_id_path + "protein2protein.tmp.csv", "w")
@@ -36,37 +38,73 @@ def create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path = '
     print("recid,phash,qhash", file=outfile_p2c_base_window)
 
     merge_sorted_coords_csv = sample_id_path + "merged_sorted_coords.tmp.csv"
-    
+
     # creates csvs with all pairings between proteins and CRISPRs that are either adjacent ('pairs') or within a genomic neighbourhood ('neighbours')
     create_protein_pair_csv(merge_sorted_coords_csv, outfile_prot_pair, outfile_prot_crispr_pair)
     create_protein_window_csv(merge_sorted_coords_csv, max_distance, outfile_p2p_base_window, outfile_p2c_base_window)
 
     outfile_prot_pair.close(), outfile_prot_crispr_pair.close(), outfile_p2p_base_window.close(), outfile_p2c_base_window.close()
 
+
 # allows proteins near CRISPRs to be mapped to each other as neighbours
-def make_merged_coords_csv(sample_id, samples_path = ''):
+def make_merged_coords_csv(sample_id, samples_path=""):
     sample_id_path = samples_path + sample_id + "/"
-    os.system("cat " + sample_id_path + "gene_coords.tmp.csv | sed -e '1s/phash/hash/' | cut -d',' -f 1-5 | "
-                                        "sed '1s/$/,is_crispr/; 2,$s/$/,0/' > " + sample_id_path + "gene_coords_m.tmp.csv")
-    os.system("cat " + sample_id_path + "crispr_coords.tmp.csv | awk 'FNR > 1' | sed '1,$s/$/,1/' > "
-              + sample_id_path + "tmp.crispr_coords.csv")
-    os.system("cat " + sample_id_path + "gene_coords_m.tmp.csv " + sample_id_path + "tmp.crispr_coords.csv > "
-              + sample_id_path + "merged_coords.tmp.csv")
-    os.system("head -n1 " + sample_id_path + "merged_coords.tmp.csv > " + sample_id_path +
-              "merged_sorted_coords.tmp.csv && tail -n+2 " + sample_id_path + "merged_coords.tmp.csv | sort "
-              "--field-separator=',' -k1,1 -k4,4n >> " + sample_id_path + "merged_sorted_coords.tmp.csv")
-    os.system("rm " + sample_id_path + "gene_coords_m.tmp.csv " + sample_id_path + "tmp.crispr_coords.csv " + sample_id_path + "merged_coords.tmp.csv")
+    os.system(
+        "cat " + sample_id_path + "gene_coords.tmp.csv | sed -e '1s/phash/hash/' | cut -d',' -f 1-5 | "
+        "sed '1s/$/,is_crispr/; 2,$s/$/,0/' > " + sample_id_path + "gene_coords_m.tmp.csv"
+    )
+    os.system(
+        "cat "
+        + sample_id_path
+        + "crispr_coords.tmp.csv | awk 'FNR > 1' | sed '1,$s/$/,1/' > "
+        + sample_id_path
+        + "tmp.crispr_coords.csv"
+    )
+    os.system(
+        "cat "
+        + sample_id_path
+        + "gene_coords_m.tmp.csv "
+        + sample_id_path
+        + "tmp.crispr_coords.csv > "
+        + sample_id_path
+        + "merged_coords.tmp.csv"
+    )
+    os.system(
+        "head -n1 "
+        + sample_id_path
+        + "merged_coords.tmp.csv > "
+        + sample_id_path
+        + "merged_sorted_coords.tmp.csv && tail -n+2 "
+        + sample_id_path
+        + "merged_coords.tmp.csv | sort "
+        "--field-separator=',' -k1,1 -k4,4n >> " + sample_id_path + "merged_sorted_coords.tmp.csv"
+    )
+    os.system(
+        "rm "
+        + sample_id_path
+        + "gene_coords_m.tmp.csv "
+        + sample_id_path
+        + "tmp.crispr_coords.csv "
+        + sample_id_path
+        + "merged_coords.tmp.csv"
+    )
 
 
 def create_protein_pair_csv(gene_coords_csv, outfile_prot_pair, outfile_prot_crispr_pair):
-    with open(gene_coords_csv, 'r') as g:
+    with open(gene_coords_csv, "r") as g:
         infile = reader(g)
         header = next(infile)
         row1 = next(infile)
         recid, old_phash, old_chash, old_start_coord, old_is_crispr = row1[0], row1[1], row1[2], row1[3], row1[5]
         if header is not None:
             for line in infile:
-                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = line[0], line[1], line[2], line[3], line[5]
+                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = (
+                    line[0],
+                    line[1],
+                    line[2],
+                    line[3],
+                    line[5],
+                )
                 if newGene_is_same_contig(old_chash, cur_chash) and is_protein2protein(old_is_crispr, cur_is_crispr):
                     print(recid + "," + cur_phash + "," + old_phash, file=outfile_prot_pair)
                 elif newGene_is_same_contig(old_chash, cur_chash):
@@ -75,9 +113,10 @@ def create_protein_pair_csv(gene_coords_csv, outfile_prot_pair, outfile_prot_cri
                 old_chash = cur_chash
                 old_is_crispr = cur_is_crispr
 
+
 def create_protein_window_csv(merge_coords_csv, max_distance, outfile_p2p, outfile_p2c):
     base_neigh_queue = deque()
-    with open(merge_coords_csv, 'r') as f:
+    with open(merge_coords_csv, "r") as f:
         infile = reader(f)
         header = next(infile)
         row1 = next(infile)
@@ -86,24 +125,36 @@ def create_protein_window_csv(merge_coords_csv, max_distance, outfile_p2p, outfi
         if header is not None:
             for line in infile:
 
-                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = line[0], line[1], line[2], line[3], line[5]
+                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = (
+                    line[0],
+                    line[1],
+                    line[2],
+                    line[3],
+                    line[5],
+                )
                 for _dict in base_neigh_queue:
                     old_phash = _dict["phash"]
-                    if newGene_is_same_contig(old_chash, cur_chash) and is_protein2protein(old_is_crispr, cur_is_crispr):
+                    if newGene_is_same_contig(old_chash, cur_chash) and is_protein2protein(
+                        old_is_crispr, cur_is_crispr
+                    ):
                         print(recid + "," + cur_phash + "," + old_phash, file=outfile_p2p)
-                    elif newGene_is_same_contig(old_chash, cur_chash) and is_protein2crispr(old_is_crispr, cur_is_crispr) and int(cur_is_crispr):
+                    elif (
+                        newGene_is_same_contig(old_chash, cur_chash)
+                        and is_protein2crispr(old_is_crispr, cur_is_crispr)
+                        and int(cur_is_crispr)
+                    ):
                         print(recid + "," + cur_phash + "," + old_phash, file=outfile_p2c)
 
-                base_neigh_queue = update_base_neigh_queue(base_neigh_queue, cur_phash, old_chash,
-                                                       cur_chash, max_distance, cur_start_coord,
-                                                       old_start_coord)
+                base_neigh_queue = update_base_neigh_queue(
+                    base_neigh_queue, cur_phash, old_chash, cur_chash, max_distance, cur_start_coord, old_start_coord
+                )
                 old_start_coord = cur_start_coord
                 old_chash = cur_chash
                 old_is_crispr = cur_is_crispr
 
+
 # the queue is a sliding window that defines a query protein or crispr's genomic neighbourhood
-def update_base_neigh_queue(queue, cur_phash, old_chash, cur_chash, max_distance, new_coord,
-                        old_coord):
+def update_base_neigh_queue(queue, cur_phash, old_chash, cur_chash, max_distance, new_coord, old_coord):
     if newGene_is_same_contig(old_chash, cur_chash):
         while (int(new_coord) - int(queue[-1]["start_coord"])) > max_distance:
             queue.pop()
@@ -115,16 +166,22 @@ def update_base_neigh_queue(queue, cur_phash, old_chash, cur_chash, max_distance
         queue.appendleft({"phash": cur_phash, "start_coord": new_coord})
     return queue
 
+
 def newGene_is_same_contig(old_chash, cur_chash):
     return old_chash == cur_chash
+
 
 def is_protein2protein(old_node_is_crispr, cur_node_is_crispr):
     return not (int(old_node_is_crispr) or int(cur_node_is_crispr))
 
-def is_protein2crispr(old_node_is_crispr, cur_node_is_crispr):
-    return (int(old_node_is_crispr) and not int(cur_node_is_crispr)) or (not int(old_node_is_crispr) and int(cur_node_is_crispr))
 
-def load_protein_coords(sample_id, samples_path=''):
+def is_protein2crispr(old_node_is_crispr, cur_node_is_crispr):
+    return (int(old_node_is_crispr) and not int(cur_node_is_crispr)) or (
+        not int(old_node_is_crispr) and int(cur_node_is_crispr)
+    )
+
+
+def load_protein_coords(sample_id, samples_path=""):
     conn = graphdb.Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
     cmd = """
           USING PERIODIC COMMIT
@@ -133,11 +190,12 @@ def load_protein_coords(sample_id, samples_path=''):
           WHERE p.hashid = row.phash AND c.hashid = row.chash
           MERGE (p)-[r:GeneCoord {{start: row.start, end: row.end, orient: row.orient}}]->(c)
           """.format(
-        csv=abspath(samples_path + sample_id + '/gene_coords.tmp.csv')
+        csv=abspath(samples_path + sample_id + "/gene_coords.tmp.csv")
     )
     print(cmd)
     conn.query(cmd, db=DBNAME)
     conn.close()
+
 
 # all input csvs have two columns - one for donor protein's phash, other for recipient
 def load_csv(csv_path_p2p, csv_path_p2c, csv_path_p2p_window, csv_path_p2c_window):
@@ -190,4 +248,3 @@ def load_csv(csv_path_p2p, csv_path_p2c, csv_path_p2p_window, csv_path_p2c_windo
     print(cmd_p2p_window_edges)
     conn.query(cmd_p2p_window_edges, db=DBNAME)
     conn.close()
-

--- a/genegraphdb/proteinnode.py
+++ b/genegraphdb/proteinnode.py
@@ -1,18 +1,12 @@
-from genegraphdb import *
-from genegraphdb import graphdb
-from genegraphdb import _load
-from genegraphdb import testing
-from Bio import SeqIO
-import gzip
-import re
-import sys
 import os
-from os import remove
-from os.path import abspath
 import time
 from collections import deque
-import csv
 from csv import reader
+from os.path import abspath
+
+from genegraphdb import *
+from genegraphdb import graphdb
+
 
 def connect_proteins_crisprs(sample_id, max_distance, samples_path = ''):
     sample_id_path = samples_path + sample_id + "/"

--- a/genegraphdb/proteinnodesql.py
+++ b/genegraphdb/proteinnodesql.py
@@ -1,19 +1,9 @@
-from genegraphdb import *
-from genegraphdb import graphdb
-from genegraphdb import _load
-from genegraphdb import testing
-from Bio import SeqIO
-import gzip
-import re
-import sys
 import os
-from os import remove
-from os.path import abspath
+import sqlite3
 import time
 from collections import deque
-import csv
 from csv import reader
-import sqlite3
+
 
 def connect_proteins_crisprs(sample_id, max_distance, samples_path = ''):
     sample_id_path = samples_path + sample_id + "/"

--- a/genegraphdb/proteinnodesql.py
+++ b/genegraphdb/proteinnodesql.py
@@ -5,22 +5,24 @@ from collections import deque
 from csv import reader
 
 
-def connect_proteins_crisprs(sample_id, max_distance, samples_path = ''):
+def connect_proteins_crisprs(sample_id, max_distance, samples_path=""):
     sample_id_path = samples_path + sample_id + "/"
     print("Loading protein2protein edges...")
     tic = time.time()
     create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path)
-    load_csv(sample_id_path + "protein2protein.tmp.sql.csv",
-             sample_id_path + "protein2crispr.tmp.sql.csv",
-             sample_id_path + "protein2protein_window.tmp.sql.csv",
-             sample_id_path + "protein2crispr_window.tmp.sql.csv")
-
+    load_csv(
+        sample_id_path + "protein2protein.tmp.sql.csv",
+        sample_id_path + "protein2crispr.tmp.sql.csv",
+        sample_id_path + "protein2protein_window.tmp.sql.csv",
+        sample_id_path + "protein2crispr_window.tmp.sql.csv",
+    )
 
     toc = time.time()
     print("Loading protein2protein edges took %f seconds" % (toc - tic))
-    return toc-tic
+    return toc - tic
 
-def create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path = ''):
+
+def create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path=""):
     sample_id_path = samples_path + sample_id + "/"
     make_merged_coords_csv(sample_id, samples_path)
     outfile_prot_pair = open(sample_id_path + "protein2protein.tmp.sql.csv", "w")
@@ -32,36 +34,73 @@ def create_all_protein_crispr_edge_csv(sample_id, max_distance, samples_path = '
     print("recid,phash,qhash", file=outfile_p2p_base_window)
     print("recid,phash,qhash", file=outfile_p2c_base_window)
 
-    merge_sorted_coords_csv = sample_id_path + "merged_sorted_coords.tmp.sql.csv" 
-        # creates csvs with all pairings between proteins and CRISPRs that are either adjacent ('pairs') or within a genomic neighbourhood ('neighbours')
+    merge_sorted_coords_csv = sample_id_path + "merged_sorted_coords.tmp.sql.csv"
+    # creates csvs with all pairings between proteins and CRISPRs that are either adjacent ('pairs') or within a genomic neighbourhood ('neighbours')
     create_protein_pair_csv(merge_sorted_coords_csv, outfile_prot_pair, outfile_prot_crispr_pair)
     create_protein_window_csv(merge_sorted_coords_csv, max_distance, outfile_p2p_base_window, outfile_p2c_base_window)
 
     outfile_prot_pair.close(), outfile_prot_crispr_pair.close(), outfile_p2p_base_window.close(), outfile_p2c_base_window.close()
 
+
 # allows proteins near CRISPRs to be mapped to each other as neighbours
-def make_merged_coords_csv(sample_id, samples_path = ''):
+def make_merged_coords_csv(sample_id, samples_path=""):
     sample_id_path = samples_path + sample_id + "/"
-    os.system("cat " + sample_id_path + "gene_coords.tmp.sql.csv | sed -e '1s/phash/hash/' | cut -d',' -f 1-5 | "
-                                        "sed '1s/$/,is_crispr/; 2,$s/$/,0/' > " + sample_id_path + "gene_coords_m.tmp.sql.csv")
-    os.system("cat " + sample_id_path + "crispr_coords.tmp.sql.csv | awk 'FNR > 1' | sed '1,$s/$/,1/' > "
-              + sample_id_path + "tmp.crispr_coords.sql.csv")
-    os.system("cat " + sample_id_path + "gene_coords_m.tmp.sql.csv " + sample_id_path + "tmp.crispr_coords.sql.csv > "
-              + sample_id_path + "merged_coords.tmp.sql.csv")
-    os.system("head -n1 " + sample_id_path + "merged_coords.tmp.sql.csv > " + sample_id_path +
-              "merged_sorted_coords.tmp.sql.csv && tail -n+2 " + sample_id_path + "merged_coords.tmp.sql.csv | sort "
-              "--field-separator=',' -k1,1 -k4,4n >> " + sample_id_path + "merged_sorted_coords.tmp.sql.csv")
-    os.system("rm " + sample_id_path + "gene_coords_m.tmp.sql.csv " + sample_id_path + "tmp.crispr_coords.sql.csv " + sample_id_path + "merged_coords.tmp.sql.csv")
+    os.system(
+        "cat " + sample_id_path + "gene_coords.tmp.sql.csv | sed -e '1s/phash/hash/' | cut -d',' -f 1-5 | "
+        "sed '1s/$/,is_crispr/; 2,$s/$/,0/' > " + sample_id_path + "gene_coords_m.tmp.sql.csv"
+    )
+    os.system(
+        "cat "
+        + sample_id_path
+        + "crispr_coords.tmp.sql.csv | awk 'FNR > 1' | sed '1,$s/$/,1/' > "
+        + sample_id_path
+        + "tmp.crispr_coords.sql.csv"
+    )
+    os.system(
+        "cat "
+        + sample_id_path
+        + "gene_coords_m.tmp.sql.csv "
+        + sample_id_path
+        + "tmp.crispr_coords.sql.csv > "
+        + sample_id_path
+        + "merged_coords.tmp.sql.csv"
+    )
+    os.system(
+        "head -n1 "
+        + sample_id_path
+        + "merged_coords.tmp.sql.csv > "
+        + sample_id_path
+        + "merged_sorted_coords.tmp.sql.csv && tail -n+2 "
+        + sample_id_path
+        + "merged_coords.tmp.sql.csv | sort "
+        "--field-separator=',' -k1,1 -k4,4n >> " + sample_id_path + "merged_sorted_coords.tmp.sql.csv"
+    )
+    os.system(
+        "rm "
+        + sample_id_path
+        + "gene_coords_m.tmp.sql.csv "
+        + sample_id_path
+        + "tmp.crispr_coords.sql.csv "
+        + sample_id_path
+        + "merged_coords.tmp.sql.csv"
+    )
+
 
 def create_protein_pair_csv(gene_coords_csv, outfile_prot_pair, outfile_prot_crispr_pair):
-    with open(gene_coords_csv, 'r') as g:
+    with open(gene_coords_csv, "r") as g:
         infile = reader(g)
         header = next(infile)
         row1 = next(infile)
         recid, old_phash, old_chash, old_start_coord, old_is_crispr = row1[0], row1[1], row1[2], row1[3], row1[5]
         if header is not None:
             for line in infile:
-                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = line[0], line[1], line[2], line[3], line[5]
+                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = (
+                    line[0],
+                    line[1],
+                    line[2],
+                    line[3],
+                    line[5],
+                )
                 if newGene_is_same_contig(old_chash, cur_chash) and is_protein2protein(old_is_crispr, cur_is_crispr):
                     print(recid + "," + cur_phash + "," + old_phash, file=outfile_prot_pair)
                 elif newGene_is_same_contig(old_chash, cur_chash):
@@ -70,9 +109,10 @@ def create_protein_pair_csv(gene_coords_csv, outfile_prot_pair, outfile_prot_cri
                 old_chash = cur_chash
                 old_is_crispr = cur_is_crispr
 
+
 def create_protein_window_csv(merge_coords_csv, max_distance, outfile_p2p, outfile_p2c):
     base_neigh_queue = deque()
-    with open(merge_coords_csv, 'r') as f:
+    with open(merge_coords_csv, "r") as f:
         infile = reader(f)
         header = next(infile)
         row1 = next(infile)
@@ -81,24 +121,36 @@ def create_protein_window_csv(merge_coords_csv, max_distance, outfile_p2p, outfi
         if header is not None:
             for line in infile:
 
-                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = line[0], line[1], line[2], line[3], line[5]
+                recid, cur_phash, cur_chash, cur_start_coord, cur_is_crispr = (
+                    line[0],
+                    line[1],
+                    line[2],
+                    line[3],
+                    line[5],
+                )
                 for _dict in base_neigh_queue:
                     old_phash = _dict["phash"]
-                    if newGene_is_same_contig(old_chash, cur_chash) and is_protein2protein(old_is_crispr, cur_is_crispr):
+                    if newGene_is_same_contig(old_chash, cur_chash) and is_protein2protein(
+                        old_is_crispr, cur_is_crispr
+                    ):
                         print(recid + "," + cur_phash + "," + old_phash, file=outfile_p2p)
-                    elif newGene_is_same_contig(old_chash, cur_chash) and is_protein2crispr(old_is_crispr, cur_is_crispr) and int(cur_is_crispr):
+                    elif (
+                        newGene_is_same_contig(old_chash, cur_chash)
+                        and is_protein2crispr(old_is_crispr, cur_is_crispr)
+                        and int(cur_is_crispr)
+                    ):
                         print(recid + "," + cur_phash + "," + old_phash, file=outfile_p2c)
 
-                base_neigh_queue = update_base_neigh_queue(base_neigh_queue, cur_phash, old_chash,
-                                                       cur_chash, max_distance, cur_start_coord,
-                                                       old_start_coord)
+                base_neigh_queue = update_base_neigh_queue(
+                    base_neigh_queue, cur_phash, old_chash, cur_chash, max_distance, cur_start_coord, old_start_coord
+                )
                 old_start_coord = cur_start_coord
                 old_chash = cur_chash
                 old_is_crispr = cur_is_crispr
 
+
 # the queue is a sliding window that defines a query protein or crispr's genomic neighbourhood
-def update_base_neigh_queue(queue, cur_phash, old_chash, cur_chash, max_distance, new_coord,
-                        old_coord):
+def update_base_neigh_queue(queue, cur_phash, old_chash, cur_chash, max_distance, new_coord, old_coord):
     if newGene_is_same_contig(old_chash, cur_chash):
         while (int(new_coord) - int(queue[-1]["start_coord"])) > max_distance:
             queue.pop()
@@ -110,37 +162,48 @@ def update_base_neigh_queue(queue, cur_phash, old_chash, cur_chash, max_distance
         queue.appendleft({"phash": cur_phash, "start_coord": new_coord})
     return queue
 
+
 def newGene_is_same_contig(old_chash, cur_chash):
     return old_chash == cur_chash
+
 
 def is_protein2protein(old_node_is_crispr, cur_node_is_crispr):
     return not (int(old_node_is_crispr) or int(cur_node_is_crispr))
 
-def is_protein2crispr(old_node_is_crispr, cur_node_is_crispr):
-    return (int(old_node_is_crispr) and not int(cur_node_is_crispr)) or (not int(old_node_is_crispr) and int(cur_node_is_crispr))
 
-def load_protein_coords(sample_id, samples_path=''):
-    con = sqlite3.connect('genegraph.db')
+def is_protein2crispr(old_node_is_crispr, cur_node_is_crispr):
+    return (int(old_node_is_crispr) and not int(cur_node_is_crispr)) or (
+        not int(old_node_is_crispr) and int(cur_node_is_crispr)
+    )
+
+
+def load_protein_coords(sample_id, samples_path=""):
+    con = sqlite3.connect("genegraph.db")
     con.execute("PRAGMA journal_mode=WAL")
     cur = con.cursor()
-    gene_coords_csv_path = samples_path + sample_id + '/gene_coords.tmp.sql.csv'
+    gene_coords_csv_path = samples_path + sample_id + "/gene_coords.tmp.sql.csv"
     gene_coords_csv = open(gene_coords_csv_path)
     rows = csv.reader(gene_coords_csv)
     next(rows)
-    cmd = '''
+    cmd = """
         INSERT OR IGNORE INTO proteincoords (phash, contighash, start, end, orientation) VALUES (?,?,?,?,?)
-        '''
+        """
     cur.executemany(cmd, ((rec[1], rec[2], rec[3], rec[4], rec[5]) for rec in rows))
     con.commit()
     con.close()
 
+
 # all input csvs have two columns - one for donor protein's phash, other for recipient
 def load_csv(csv_path_p2p, csv_path_p2c, csv_path_p2p_window, csv_path_p2c_window):
-    con = sqlite3.connect('genegraph.db')
+    con = sqlite3.connect("genegraph.db")
     con.execute("PRAGMA journal_mode=WAL")
     cur = con.cursor()
-    p2p_csv, p2c_csv, p2pwindow_csv, p2cwindow_csv= open(csv_path_p2p), open(csv_path_p2c), \
-                                                    open(csv_path_p2p_window), open(csv_path_p2c_window)
+    p2p_csv, p2c_csv, p2pwindow_csv, p2cwindow_csv = (
+        open(csv_path_p2p),
+        open(csv_path_p2c),
+        open(csv_path_p2p_window),
+        open(csv_path_p2c_window),
+    )
 
     p2p_rows = csv.reader(p2p_csv)
     next(p2p_rows)
@@ -150,10 +213,10 @@ def load_csv(csv_path_p2p, csv_path_p2c, csv_path_p2p_window, csv_path_p2c_windo
     next(p2pwindow_rows)
     p2cwindow_rows = csv.reader(p2cwindow_csv)
     next(p2cwindow_rows)
-    p2p_cmd = '''INSERT OR IGNORE INTO prot2prot (p1hash, p2hash) VALUES (?,?)'''
-    p2c_cmd = '''INSERT OR IGNORE INTO prot2crispr (p1hash, crisprhash) VALUES (?,?)'''
-    p2pwindow_cmd = '''INSERT OR IGNORE INTO prot2protwindow (p1hash, p2hash) VALUES (?,?)'''
-    p2cwindow_cmd = '''INSERT OR IGNORE INTO prot2crisprwindow (p1hash, crisprhash) VALUES (?,?)'''
+    p2p_cmd = """INSERT OR IGNORE INTO prot2prot (p1hash, p2hash) VALUES (?,?)"""
+    p2c_cmd = """INSERT OR IGNORE INTO prot2crispr (p1hash, crisprhash) VALUES (?,?)"""
+    p2pwindow_cmd = """INSERT OR IGNORE INTO prot2protwindow (p1hash, p2hash) VALUES (?,?)"""
+    p2cwindow_cmd = """INSERT OR IGNORE INTO prot2crisprwindow (p1hash, crisprhash) VALUES (?,?)"""
 
     cur.executemany(p2p_cmd, ((rec[1], rec[2]) for rec in p2p_rows))
     cur.executemany(p2c_cmd, ((rec[1], rec[2]) for rec in p2c_rows))
@@ -161,5 +224,3 @@ def load_csv(csv_path_p2p, csv_path_p2c, csv_path_p2p_window, csv_path_p2c_windo
     cur.executemany(p2cwindow_cmd, ((rec[1], rec[2]) for rec in p2cwindow_rows))
     con.commit()
     con.close()
-
-

--- a/genegraphdb/search.py
+++ b/genegraphdb/search.py
@@ -9,26 +9,30 @@ from cassandra.cluster import Cluster
 
 from genegraphdb import *
 
-#Global variables
+# Global variables
 hash_size = 25
 fileName = "uniref100.fasta"
 csv_results = "MinhashNeo4j_results_10_8.csv"
 outfile_results = open(csv_results, "w")
-#print('kmer_size,num_sequences,num_minhash,csv_time,minhash_time,protein_time,edges_time,total_time,search_time', file = outfile_results)
+# print('kmer_size,num_sequences,num_minhash,csv_time,minhash_time,protein_time,edges_time,total_time,search_time', file = outfile_results)
 
-#Calculates hashcode given salt
+# Calculates hashcode given salt
 def hashWithSalt(salt, kmer):
-     return hashlib.sha256(str(salt).encode() + kmer.strip('*').encode()).hexdigest()[0:hash_size]
-#Generates a set of kmers for a protein at the designated kmer size
+    return hashlib.sha256(str(salt).encode() + kmer.strip("*").encode()).hexdigest()[0:hash_size]
+
+
+# Generates a set of kmers for a protein at the designated kmer size
 def kmerSet(sequence, kmer_size):
     kmer_set = set()
     start_index = 0
-    while(start_index + kmer_size <= len(sequence) + 1):
+    while start_index + kmer_size <= len(sequence) + 1:
         kmerSeq = sequence[start_index : start_index + kmer_size]
         kmer_set.add(kmerSeq)
         start_index += 1
     return kmer_set
-#Minhash of particular hash function for a set of kmers
+
+
+# Minhash of particular hash function for a set of kmers
 def findMinHash(salt_num, kmers):
     min_hash = ""
     for kmer in kmers:
@@ -36,35 +40,37 @@ def findMinHash(salt_num, kmers):
         if min_hash == "" or test_min_hash < min_hash:
             min_hash = test_min_hash
     return min_hash
-#Writes protein to minhash pairs (num_min_hash possible pairs per protein)
+
+
+# Writes protein to minhash pairs (num_min_hash possible pairs per protein)
 def addSeqCSV(sequence, name, kmer_size, num_min_hash, outfile_phashes, outfile_minhashes, outfile_edges):
     kmers = kmerSet(sequence, kmer_size)
-    print(name, len(sequence), sep = ",", file = outfile_phashes)
+    print(name, len(sequence), sep=",", file=outfile_phashes)
     for salt_num in range(0, num_min_hash):
         minhash = findMinHash(salt_num, kmers)
-        #Writes to CSV
-        print(minhash, sep = ",", file = outfile_minhashes)
-        print(name, minhash, len(sequence), sep = ",", file = outfile_edges)
+        # Writes to CSV
+        print(minhash, sep=",", file=outfile_minhashes)
+        print(name, minhash, len(sequence), sep=",", file=outfile_edges)
 
 
-#Create reference Database for Neo4j w/ Minhashing
+# Create reference Database for Neo4j w/ Minhashing
 def createDB_Neo4j_MH(kmer_size, MAX_SEQUENCES, num_min_hash):
-    #Opens and reads UniRef100 database
+    # Opens and reads UniRef100 database
     tic_csv = time.time()
-    fasta_sequences_uniref = SeqIO.parse(open(fileName), 'fasta')
+    fasta_sequences_uniref = SeqIO.parse(open(fileName), "fasta")
     csv_path_edges = "minhash_gene_tmp.csv"
     outfile_edges = open(csv_path_edges, "w")
     csv_path_minhashes = "minhash_tmp.csv"
     outfile_minhashes = open(csv_path_minhashes, "w")
     csv_path_phashes = "protein_tmp.csv"
     outfile_phashes = open(csv_path_phashes, "w")
-    print('name,minhash,plen', file = outfile_edges)
-    print('name,plen', file = outfile_phashes)
-    print('minhash', file = outfile_minhashes)
+    print("name,minhash,plen", file=outfile_edges)
+    print("name,plen", file=outfile_phashes)
+    print("minhash", file=outfile_minhashes)
     num_sequences = 0
     for fasta in fasta_sequences_uniref:
         seq = str(fasta.seq)
-        hashcode = hashlib.sha256(seq.strip('*').encode()).hexdigest()
+        hashcode = hashlib.sha256(seq.strip("*").encode()).hexdigest()
         addSeqCSV(seq, hashcode, kmer_size, num_min_hash, outfile_phashes, outfile_minhashes, outfile_edges)
         if num_sequences >= MAX_SEQUENCES:
             break
@@ -76,110 +82,129 @@ def createDB_Neo4j_MH(kmer_size, MAX_SEQUENCES, num_min_hash):
     csv_time = toc_csv - tic_csv
     ##Neo4j Code
     conn = Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
-    conn.query("CREATE CONSTRAINT minhash_id ON (n:Minhash) ASSERT n.hashid IS UNIQUE", db = "neo4j")
-    #Clear previous data (remove if you're not testing)
-    conn.query("MATCH (a) -[r] -> () DELETE a, r", db = "neo4j")
-    conn.query("MATCH (a) delete a", db = "neo4j")
-    #Load minhash nodes with timers
+    conn.query("CREATE CONSTRAINT minhash_id ON (n:Minhash) ASSERT n.hashid IS UNIQUE", db="neo4j")
+    # Clear previous data (remove if you're not testing)
+    conn.query("MATCH (a) -[r] -> () DELETE a, r", db="neo4j")
+    conn.query("MATCH (a) delete a", db="neo4j")
+    # Load minhash nodes with timers
     tic_minhash = time.time()
     cmd_loadKmers = """
       USING PERIODIC COMMIT
       LOAD CSV WITH HEADERS FROM 'file:///{csv}' AS row
       WITH DISTINCT row.minhash as minhash
       MERGE (m:Minhash {{hashid: minhash}})
-      """.format(csv=abspath(csv_path_minhashes))
-    conn.query(cmd_loadKmers, db = "neo4j")
+      """.format(
+        csv=abspath(csv_path_minhashes)
+    )
+    conn.query(cmd_loadKmers, db="neo4j")
     toc_minhash = time.time()
     minhash_time = toc_minhash - tic_minhash
-    #Load protein nodes with timers
+    # Load protein nodes with timers
     tic_proteins = time.time()
     cmd_loadProteins = """
       USING PERIODIC COMMIT
       LOAD CSV WITH HEADERS FROM 'file:///{csv}' AS row
       WITH DISTINCT row.name as pname, row.plen as plength
       MERGE (p:Protein {{name: pname, length: plength}})
-      """.format(csv=abspath(csv_path_phashes))
-    conn.query(cmd_loadProteins, db = "neo4j")
+      """.format(
+        csv=abspath(csv_path_phashes)
+    )
+    conn.query(cmd_loadProteins, db="neo4j")
     toc_proteins = time.time()
     proteins_time = toc_proteins - tic_proteins
-    #Load relationships with timers
+    # Load relationships with timers
     tic_edges = time.time()
     cmd_loadRelations = """
       USING PERIODIC COMMIT
       LOAD CSV WITH HEADERS FROM 'file:///{csv}' AS row
       MATCH (m:Minhash {{hashid: row.minhash}}), (p:Protein {{name: row.name}})
       MERGE (m)-[r:MINHASH_OF]->(p)
-      """.format(csv=abspath(csv_path_edges))
-    conn.query(cmd_loadRelations, db = "neo4j")
+      """.format(
+        csv=abspath(csv_path_edges)
+    )
+    conn.query(cmd_loadRelations, db="neo4j")
     toc_edges = time.time()
     edges_time = toc_edges - tic_edges
     total_time = toc_edges - tic_csv
 
-#Search reference database (Neo4j w/ Minhashing)
+
+# Search reference database (Neo4j w/ Minhashing)
 def searchDB_Neo4j_MH(kmer_input, num_min_hash, kmer_size):
     conn = Neo4jConnection(DBURI, DBUSER, DBPASSWORD)
-    #Sample kmer_input (for testing)
+    # Sample kmer_input (for testing)
     kmer_input = "IMGPPDPILGMVRGVCIVEMGPPDPPSVTQFVVSFKAEFEDVPWLKEDIARSDAKQGSQLVALHLRLMAGGEVVNGLAKDLARQHGKSGALFYLNGLLNQSAPIFTQEPRAPYNTGNEDSPALLKIGTTIIENET"
     proteinToNum = defaultdict(lambda: 0)
     kmer_set = kmerSet(kmer_input, kmer_size)
     ticS = time.time()
-    #Add all kmers for this protein to the Neo4j database
+    # Add all kmers for this protein to the Neo4j database
     for salt_num in range(num_min_hash):
         minhash = findMinHash(salt_num, kmer_set)
         cmd = """
             MATCH (a:Minhash) - [:MINHASH_OF] ->(p:Protein)
             WHERE a.hashid ='{query_minhash}'
             RETURN p.name
-            """.format(query_minhash = minhash)
-        matchingProteins = conn.query(cmd, db = "neo4j")
-        if len( matchingProteins) != 0:
+            """.format(
+            query_minhash=minhash
+        )
+        matchingProteins = conn.query(cmd, db="neo4j")
+        if len(matchingProteins) != 0:
             for p in matchingProteins:
                 proteinToNum[p] += 1
     tocS = time.time()
     search_time = tocS - ticS
-    #Final results
-    #print(kmer_size, MAX_SEQUENCES, num_min_hash, csv_time, minhash_time, proteins_time, edges_time, total_time, search_time, sep = ",", file = outfile_results)
+    # Final results
+    # print(kmer_size, MAX_SEQUENCES, num_min_hash, csv_time, minhash_time, proteins_time, edges_time, total_time, search_time, sep = ",", file = outfile_results)
 
-#Add minhashes of sequence into SQL database
+
+# Add minhashes of sequence into SQL database
 def addSeqMinHashes(hashcode, sequence, kmer_size, num_min_hash, c):
     kmer_set = kmerSet(sequence, kmer_size)
     tmp_insertions = 0
     for salt_num in range(0, num_min_hash):
         tmp_insertions += 1
         min_hash = findMinHash(salt_num, kmer_set)
-        c.execute("""INSERT INTO minhashes
-                     VALUES (?,?)""", (hashcode, min_hash))
+        c.execute(
+            """INSERT INTO minhashes
+                     VALUES (?,?)""",
+            (hashcode, min_hash),
+        )
     return tmp_insertions
 
-#Create reference database for SQL w/ Minhashing
+
+# Create reference database for SQL w/ Minhashing
 def createDB_SQL_MH(kmer_size, MAX_SEQUENCES, num_min_hash):
-    #Variables
+    # Variables
     rundate = "8_17_21"
-    #hash_size = 25
+    # hash_size = 25
     results_csv = "create_runtimes_" + rundate + ".csv"
     outfile_results = open(results_csv, "w")
-    print('kmer_length,num_sequences,num_minhashes,insertion_time,index_time,total_time,num_rows,search_speed', file = outfile_results)
+    print(
+        "kmer_length,num_sequences,num_minhashes,insertion_time,index_time,total_time,num_rows,search_speed",
+        file=outfile_results,
+    )
 
-    #Create SQlite variables/table(s)
-    conn = sqlite3.connect('SC_MH.db')
+    # Create SQlite variables/table(s)
+    conn = sqlite3.connect("SC_MH.db")
     c = conn.cursor()
     c.execute("""DROP TABLE minhashes""")
-    c.execute("""CREATE TABLE IF NOT EXISTS minhashes
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS minhashes
            (phash text,
-            minhash text)""")
-    #Variables
+            minhash text)"""
+    )
+    # Variables
     referenceDB = "uniref100.fasta"
     num_sequences = 0
     num_insertions = 0
-    #Add to SQL table
+    # Add to SQL table
     tic = time.time()
     c.execute("PRAGMA synchronous = OFF")
     c.execute("PRAGMA journal_mode = MEMORY")
     c.execute("BEGIN TRANSACTION")
-    fasta_sequences_uniref = SeqIO.parse(open(referenceDB), 'fasta')
+    fasta_sequences_uniref = SeqIO.parse(open(referenceDB), "fasta")
     for fasta in fasta_sequences_uniref:
         seq = str(fasta.seq)
-        hashcode = hashlib.sha256(seq.strip('*').encode()).hexdigest()
+        hashcode = hashlib.sha256(seq.strip("*").encode()).hexdigest()
         num_insertions += addSeqMinHashes(hashcode, seq, kmer_size, num_min_hash, c)
         if num_sequences == MAX_SEQUENCES:
             break
@@ -195,10 +220,11 @@ def createDB_SQL_MH(kmer_size, MAX_SEQUENCES, num_min_hash):
     total_time = tocInd - tic
     c.execute("END TRANSACTION")
 
+
 def searchDB_SQL_MH(kmer_input, kmer_size, num_min_hash):
-    conn = sqlite3.connect('SC_MH.db')
+    conn = sqlite3.connect("SC_MH.db")
     c = conn.cursor()
-    #Sample kmer_input (for testing)
+    # Sample kmer_input (for testing)
     kmer_input = "IMGPPDPILGMVRGVCIVEMGPPDPPSVTQFVVSFKAEFEDVPWLKEDIARSDAKQGSQLVALHLRMAGGEVVNGLAKDLARQHGKSGALFYLNGLLNQSAPIFTQEPRAPYNTGNEDSPALLKIGTTIIENET"
     phash_to_num = defaultdict(lambda: 0)
     ticS = time.time()
@@ -211,52 +237,61 @@ def searchDB_SQL_MH(kmer_input, kmer_size, num_min_hash):
             phash_to_num[phash] += 1
     tocS = time.time()
     search_time = tocS - ticS
-    #print(kmer_size, MAX_SEQUENCES, num_min_hash, insertion_time, index_time, total_time, num_insertions,search_time, sep =",", file = outfile_results)
+    # print(kmer_size, MAX_SEQUENCES, num_min_hash, insertion_time, index_time, total_time, num_insertions,search_time, sep =",", file = outfile_results)
     print("DONE")
     conn.close()
 
-#Generates a set of kmers for a sequence at the designated kmer size
+
+# Generates a set of kmers for a sequence at the designated kmer size
 def kmerSet(sequence, kmer_size):
     kmer_set = set()
     start_index = 0
-    while(start_index + kmer_size <= len(sequence) + 1):
+    while start_index + kmer_size <= len(sequence) + 1:
         kmerSeq = sequence[start_index : start_index + kmer_size]
         kmer_set.add(kmerSeq)
         start_index += 1
     return kmer_set
-#Add minhashes of sequence into SQL database
+
+
+# Add minhashes of sequence into SQL database
 def addSeqKmers(hashcode, sequence, kmer_size, c):
     kmer_set = kmerSet(sequence, kmer_size)
     tmp_insertions = 0
     for kmer in kmer_set:
         tmp_insertions += 1
-        c.execute("""INSERT INTO kmers
-                     VALUES (?,?)""", (hashcode, kmer))
+        c.execute(
+            """INSERT INTO kmers
+                     VALUES (?,?)""",
+            (hashcode, kmer),
+        )
     return tmp_insertions
 
-#SQL w/ Kmers
+
+# SQL w/ Kmers
 def createDB_SQL_Kmer(kmer_size, MAX_SEQUENCES):
-    #"Global" variables
+    # "Global" variables
     referenceDB = "uniref100.fasta"
     csv_path = "kmerSQL_results_8_18.csv"
     outfile = open(csv_path, "w")
-    #Add to SQL table
-    conn = sqlite3.connect('SC.db')
+    # Add to SQL table
+    conn = sqlite3.connect("SC.db")
     c = conn.cursor()
     c.execute("""DROP TABLE kmers""")
-    c.execute("""CREATE TABLE IF NOT EXISTS kmers
+    c.execute(
+        """CREATE TABLE IF NOT EXISTS kmers
                 (phash text,
-                 kmer text)""")
+                 kmer text)"""
+    )
     c.execute("PRAGMA synchronous = OFF")
     c.execute("PRAGMA journal_mode = MEMORY")
     c.execute("BEGIN TRANSACTION")
     num_sequences = 0
     num_insertions = 0
-    fasta_sequences_uniref = SeqIO.parse(open(referenceDB), 'fasta')
+    fasta_sequences_uniref = SeqIO.parse(open(referenceDB), "fasta")
     tic = time.time()
     for fasta in fasta_sequences_uniref:
         seq = str(fasta.seq)
-        hashcode = hashlib.sha256(seq.strip('*').encode()).hexdigest()
+        hashcode = hashlib.sha256(seq.strip("*").encode()).hexdigest()
         num_insertions += addSeqKmers(hashcode, seq, kmer_size, c)
         if num_sequences == MAX_SEQUENCES:
             break
@@ -264,16 +299,18 @@ def createDB_SQL_Kmer(kmer_size, MAX_SEQUENCES):
     c.execute("END TRANSACTION")
     toc = time.time()
     insertion_time = toc - tic
-    #Create index on kmers (for searching after)
+    # Create index on kmers (for searching after)
     c.execute("BEGIN TRANSACTION")
     ticInd = time.time()
     c.execute("CREATE INDEX kmerID on kmers(kmer)")
     c.execute("END TRANSACTION")
-    tocInd= time.time()
+    tocInd = time.time()
     index_time = tocInd - ticInd
     total_time = tocInd - tic
+
+
 def searchDB_SQL_Kmer(kmer_size):
-    conn = sqlite3.connect('SC.db')
+    conn = sqlite3.connect("SC.db")
     c = conn.cursor()
     kmer_input = "IMGPPDPILGMVRGVCIVEMGPPDPPSVTQFVVSFKAEFEDVPWLKEDIARSDAKQGSQLVALHLRMAGGEVVNGLAKDLARQHGKSGALFYLNGLLNQSAPIFTQEPRAPYNTGNEDSPALLKIGTTIIENET"
     phash_to_num = defaultdict(lambda: 0)
@@ -286,16 +323,16 @@ def searchDB_SQL_Kmer(kmer_size):
             phash_to_num[phash] += 1
     tocS = time.time()
     search_time = tocS - ticS
-    #print(kmer_size, MAX_SEQUENCES, insertion_time, index_time, total_time, num_insertions, search_time, sep = ",", file = outfile)   
+    # print(kmer_size, MAX_SEQUENCES, insertion_time, index_time, total_time, num_insertions, search_time, sep = ",", file = outfile)
 
 
-#Cassandra w/ Kmers
+# Cassandra w/ Kmers
 def createDB_Cass_Kmer(kmer_size, MAX_SEQUENCES):
     referenceDB = "uniref100.fasta"
     csv_path = "kmerCass_results_8_18.csv"
     outfile = open(csv_path, "w")
     cluster = Cluster()
-    session = cluster.connect('kmers_test')
+    session = cluster.connect("kmers_test")
     session.execute("DROP TABLE kmersTable")
     createTableQry = """
     CREATE TABLE IF NOT EXISTS kmersTable(
@@ -306,20 +343,22 @@ def createDB_Cass_Kmer(kmer_size, MAX_SEQUENCES):
     session.execute(createTableQry)
     num_sequences = 0
     num_insertions = 0
-    fasta_sequences_uniref = SeqIO.parse(open(referenceDB), 'fasta')
+    fasta_sequences_uniref = SeqIO.parse(open(referenceDB), "fasta")
     tic = time.time()
     for fasta in fasta_sequences_uniref:
         seq = str(fasta.seq)
-        hashcode = hashlib.sha256(seq.strip('*').encode()).hexdigest()
+        hashcode = hashlib.sha256(seq.strip("*").encode()).hexdigest()
         num_insertions += addSeqKmers(hashcode, seq, kmer_size, session)
         if num_sequences == MAX_SEQUENCES:
             break
         num_sequences += 1
     toc = time.time()
     insertion_time = toc - tic
+
+
 def searchDB_Cass_Kmer(kmer_size):
     cluster = Cluster()
-    session = cluster.connect('kmers_test')
+    session = cluster.connect("kmers_test")
     kmer_input = "IMGPPDPILGMVRGVCIVEMGPPDPPSVTQFVVSFKAEFEDVPWLKEDIARSDAKQGSQLVALHLRMAGGEVVNGLAKDLARQHGKSGALFYLNGLLNQSAPIFTQEPRAPYNTGNEDSPALLKIGTTIIENET"
     phash_to_num = defaultdict(lambda: 0)
     ticS = time.time()
@@ -331,4 +370,4 @@ def searchDB_Cass_Kmer(kmer_size):
             phash_to_num[phash] += 1
     tocS = time.time()
     search_time = tocS - ticS
-    #print(kmer_size, MAX_SEQUENCES, insertion_time, num_insertions, search_time, sep = ",", file = outfile)
+    # print(kmer_size, MAX_SEQUENCES, insertion_time, num_insertions, search_time, sep = ",", file = outfile)

--- a/genegraphdb/search.py
+++ b/genegraphdb/search.py
@@ -1,12 +1,13 @@
-from collections import defaultdict
-from genegraphdb import *
-from neo4j import GraphDatabase
-from Bio import SeqIO
 import hashlib
-import time
-from os.path import abspath
 import sqlite3
+import time
+from collections import defaultdict
+from os.path import abspath
+
+from Bio import SeqIO
 from cassandra.cluster import Cluster
+
+from genegraphdb import *
 
 #Global variables
 hash_size = 25

--- a/genegraphdb/sqldb.py
+++ b/genegraphdb/sqldb.py
@@ -1,8 +1,8 @@
-from genegraphdb import *
-from genegraphdb import graphdb
 import os
-import subprocess
 import sqlite3
+
+from genegraphdb import *
+
 
 def hasdb():
     if "genegraph.db" in os.listdir():

--- a/genegraphdb/sqldb.py
+++ b/genegraphdb/sqldb.py
@@ -9,25 +9,33 @@ def hasdb():
         return True
     return False
 
+
 def createdb():
     print("Creating database: %s" % DBNAME)
-    con = sqlite3.connect('genegraph.db')
+    con = sqlite3.connect("genegraph.db")
     cur = con.cursor()
-    cur.execute('''CREATE TABLE proteins (hashid text, length real, PRIMARY KEY(hashid, length))''')
-    cur.execute('''CREATE TABLE samples (sampleid text, PRIMARY KEY (sampleid))''')
-    cur.execute('''CREATE TABLE crisprs (hashid text, PRIMARY KEY (hashid))''')
-    cur.execute('''CREATE TABLE contigs (hashid text, length real, PRIMARY KEY (hashid, length))''')
-    cur.execute('''CREATE TABLE contig2sample (contighashid text, sampleid text, PRIMARY KEY (contighashid, sampleid))''')
-    cur.execute('''CREATE TABLE crisprcoords (crisprhash text, contighash text, start real, end real, PRIMARY KEY (crisprhash, contighash, start))''')
-    cur.execute('''CREATE TABLE proteincoords (phash text, contighash text, start real, end real, orientation text, PRIMARY KEY (phash, contighash, start))''')
-    cur.execute('''CREATE TABLE prot2prot (p1hash text, p2hash text, PRIMARY KEY (p1hash, p2hash))''')
-    cur.execute('''CREATE TABLE prot2crispr (p1hash text, crisprhash text, PRIMARY KEY (p1hash, crisprhash))''')
-    cur.execute('''CREATE TABLE prot2protwindow (p1hash text, p2hash text, PRIMARY KEY (p1hash, p2hash))''')
-    cur.execute('''CREATE TABLE prot2crisprwindow (p1hash text, crisprhash text, PRIMARY KEY (p1hash, crisprhash))''')
+    cur.execute("""CREATE TABLE proteins (hashid text, length real, PRIMARY KEY(hashid, length))""")
+    cur.execute("""CREATE TABLE samples (sampleid text, PRIMARY KEY (sampleid))""")
+    cur.execute("""CREATE TABLE crisprs (hashid text, PRIMARY KEY (hashid))""")
+    cur.execute("""CREATE TABLE contigs (hashid text, length real, PRIMARY KEY (hashid, length))""")
+    cur.execute(
+        """CREATE TABLE contig2sample (contighashid text, sampleid text, PRIMARY KEY (contighashid, sampleid))"""
+    )
+    cur.execute(
+        """CREATE TABLE crisprcoords (crisprhash text, contighash text, start real, end real, PRIMARY KEY (crisprhash, contighash, start))"""
+    )
+    cur.execute(
+        """CREATE TABLE proteincoords (phash text, contighash text, start real, end real, orientation text, PRIMARY KEY (phash, contighash, start))"""
+    )
+    cur.execute("""CREATE TABLE prot2prot (p1hash text, p2hash text, PRIMARY KEY (p1hash, p2hash))""")
+    cur.execute("""CREATE TABLE prot2crispr (p1hash text, crisprhash text, PRIMARY KEY (p1hash, crisprhash))""")
+    cur.execute("""CREATE TABLE prot2protwindow (p1hash text, p2hash text, PRIMARY KEY (p1hash, p2hash))""")
+    cur.execute("""CREATE TABLE prot2crisprwindow (p1hash text, crisprhash text, PRIMARY KEY (p1hash, crisprhash))""")
     con.close()
-    #os.system("sqlite3 genegraph.db")
+    # os.system("sqlite3 genegraph.db")
 
     print("SQL database created")
+
 
 def cleardb():
     os.system("rm genegraph.db")

--- a/genegraphdb/testing.py
+++ b/genegraphdb/testing.py
@@ -1,12 +1,13 @@
-from genegraphdb import *
 import csv
 import os
-from datetime import datetime
-import unittest
-import pandas as pd
-from genegraphdb import variables_global as vars_glob
 import sqlite3
+import unittest
+from datetime import datetime
+
 import numpy as np
+
+from genegraphdb import variables_global as vars_glob
+
 
 # all of these tests were performed locally before implementing the graph database on gcloud
 # some tests rely on sample directories that are organized differently from the sample directories on gcloud

--- a/genegraphdb/testing.py
+++ b/genegraphdb/testing.py
@@ -11,16 +11,17 @@ from genegraphdb import variables_global as vars_glob
 
 # all of these tests were performed locally before implementing the graph database on gcloud
 # some tests rely on sample directories that are organized differently from the sample directories on gcloud
-class testSQLiteNodeConnections(unittest.TestCase): # to do - change class name; outdated
+class testSQLiteNodeConnections(unittest.TestCase):  # to do - change class name; outdated
     def test_allSQLite_tables_full(self):
         sql_tables = vars_glob.sql_tables
-        con = sqlite3.connect('genegraph.db')
+        con = sqlite3.connect("genegraph.db")
         cur = con.cursor()
         for table in sql_tables:
             cmd = "SELECT count(*) FROM {}".format(table)
             cur.execute(cmd)
             rv = cur.fetchall()
             self.assertTrue(rv[0][0] > 0)
+
     def test_neo4J_SQL_filesizematch(self):
         paths_genomes_annot = []
         for dir in os.listdir("genomes_annot_2/"):
@@ -30,12 +31,12 @@ class testSQLiteNodeConnections(unittest.TestCase): # to do - change class name;
                 if os.path.isdir(sample_path):
                     paths_genomes_annot.append(sample_path)
         tempSQLfiles_list = vars_glob.temp_files_list
-        allfiles_list = [(file.replace("sql.",""), file) for file in tempSQLfiles_list]
+        allfiles_list = [(file.replace("sql.", ""), file) for file in tempSQLfiles_list]
         for sample_path in paths_genomes_annot:
             for filepair in allfiles_list:
                 filepaths = (sample_path + filepair[0], sample_path + filepair[1])
                 self.assertEqual(os.path.getsize(filepaths[0]), os.path.getsize(filepaths[1]))
-                
+
     # mtime describes the time a file was last modified
     def test_all_sqlfiles_updated(self):
         paths_genomes_annot = []
@@ -53,27 +54,34 @@ class testSQLiteNodeConnections(unittest.TestCase): # to do - change class name;
                 mtimes_sqlfiles.append(os.path.getmtime(filepath))
         mtime_ref = mtimes_sqlfiles[0]
         for mtime in mtimes_sqlfiles:
-            self.assertTrue(np.abs(mtime - mtime_ref) < 100) # all samples from genomes_annot directory should be loaded in the ggdb in under 100 mtime units
+            self.assertTrue(
+                np.abs(mtime - mtime_ref) < 100
+            )  # all samples from genomes_annot directory should be loaded in the ggdb in under 100 mtime units
+
     def test_sqlite_dbsize_stable(self):
         init_db_size = os.path.getsize("genegraph.db")
         os.system("ggdb load multisql -s genomes_annot/ -c '' ")
         final_db_size = os.path.getsize("genegraph.db")
         self.assertEqual(init_db_size, final_db_size)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()
 
-def get_runtime_summarystats(comment="", prot_time = 0, samples_path = "", infile_name = "ggdb_load_stats.csv", outfile_name = "ggdb_summary_stats.csv"):
+
+def get_runtime_summarystats(
+    comment="", prot_time=0, samples_path="", infile_name="ggdb_load_stats.csv", outfile_name="ggdb_summary_stats.csv"
+):
     if samples_path != "":
         infile_name = samples_path + infile_name
         outfile_name = samples_path + outfile_name
     outfile = open(outfile_name, "a")
-    with open(infile_name, newline='') as f:
+    with open(infile_name, newline="") as f:
         reader = csv.reader(f)
         next(reader)
         p2p_edge_time, cur_load_time = 0, 0
         for line in f:
-            line = line.strip('\n').split(',')
+            line = line.strip("\n").split(",")
             cur_load_time = float(line[1])
             p2p_edge_time = line[2]
             if p2p_edge_time != "null":
@@ -84,7 +92,7 @@ def get_runtime_summarystats(comment="", prot_time = 0, samples_path = "", infil
         try:
             next(reader)
             for line in f:
-                line = line.strip('\n').split(',')
+                line = line.strip("\n").split(",")
                 cur_load_time += float(line[1])
                 if p2p_edge_time != "null":
                     p2p_edge_time += float(line[2])
@@ -94,6 +102,7 @@ def get_runtime_summarystats(comment="", prot_time = 0, samples_path = "", infil
             cur_load_time += p2p_edge_time
         print(str(cur_load_time) + "," + str(p2p_edge_time) + "," + comment, file=outfile)
 
+
 def clean_files(sample_id, samples_path):
     files_to_remove = vars_glob.temp_files_list
     cmd = "rm "
@@ -102,11 +111,13 @@ def clean_files(sample_id, samples_path):
     print(cmd)
     os.system(cmd)
 
+
 def log_errors_multisql_loadsql(samples_path, sample_id, exception):
     outfile = open("ggdb_multisql_errorlog.csv", "a")
     now = datetime.now()
     date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
     print(date_time + "," + samples_path + sample_id + " : " + str(exception), file=outfile)
+
 
 def log_errors_multi_loadneo4j(samples_path, sample_id, exception):
     outfile = open("ggdb_multineo4j_errorlog.csv", "a")

--- a/genegraphdb/variables_global.py
+++ b/genegraphdb/variables_global.py
@@ -1,16 +1,39 @@
 import os
 
 exclude_directories = [".git", ".idea", "venv"]
-sql_tables = ["proteins", "samples", "crisprs", "contigs", "contig2sample", "crisprcoords", "proteincoords", "prot2prot",
-                 "prot2crispr", "prot2protwindow", "prot2crisprwindow"]
-temp_files_list = ["contig2sample.tmp.sql.csv", "contigs.tmp.sql.csv", "crispr_coords.tmp.sql.csv", "CRISPRs.tmp.sql.csv",
-                       "gene_coords.tmp.sql.csv", "merged_sorted_coords.tmp.sql.csv", "merged.sorted.tmp.sql.gff",
-                       "protein2crispr_window.tmp.sql.csv", "protein2crispr.tmp.sql.csv", "protein2protein_window.tmp.sql.csv",
-                       "protein2protein.tmp.sql.csv", "proteins.tmp.sql.csv", "temp.minced.sql.gff"]
-                   # "contig2sample.tmp.csv", "contigs.tmp.csv", "crispr_coords.tmp.csv", "CRISPRs.tmp.csv",
-                   # "gene_coords.tmp.csv", "merged_sorted_coords.tmp.csv", "merged.sorted.tmp.gff",
-                   # "protein2crispr_window.tmp.csv", "protein2crispr.tmp.csv", "protein2protein_window.tmp.csv",
-                   # "protein2protein.tmp.csv", "proteins.tmp.csv", "temp.minced.gff"]
+sql_tables = [
+    "proteins",
+    "samples",
+    "crisprs",
+    "contigs",
+    "contig2sample",
+    "crisprcoords",
+    "proteincoords",
+    "prot2prot",
+    "prot2crispr",
+    "prot2protwindow",
+    "prot2crisprwindow",
+]
+temp_files_list = [
+    "contig2sample.tmp.sql.csv",
+    "contigs.tmp.sql.csv",
+    "crispr_coords.tmp.sql.csv",
+    "CRISPRs.tmp.sql.csv",
+    "gene_coords.tmp.sql.csv",
+    "merged_sorted_coords.tmp.sql.csv",
+    "merged.sorted.tmp.sql.gff",
+    "protein2crispr_window.tmp.sql.csv",
+    "protein2crispr.tmp.sql.csv",
+    "protein2protein_window.tmp.sql.csv",
+    "protein2protein.tmp.sql.csv",
+    "proteins.tmp.sql.csv",
+    "temp.minced.sql.gff",
+]
+# "contig2sample.tmp.csv", "contigs.tmp.csv", "crispr_coords.tmp.csv", "CRISPRs.tmp.csv",
+# "gene_coords.tmp.csv", "merged_sorted_coords.tmp.csv", "merged.sorted.tmp.gff",
+# "protein2crispr_window.tmp.csv", "protein2crispr.tmp.csv", "protein2protein_window.tmp.csv",
+# "protein2protein.tmp.csv", "proteins.tmp.csv", "temp.minced.gff"]
+
 
 def get_sampleid_to_path_dict(path_drep):
     drep_samples = {}
@@ -30,6 +53,8 @@ def get_sampleid_to_path_dict(path_drep):
                                 if os.path.isdir(samp_dir):
                                     drep_samples[directory_samp] = path_4
     return drep_samples
+
+
 # sampleids_error = []
 # with open("ggdb_multisql_errorlog.csv", "r") as f:
 #     infile = reader(f)

--- a/genegraphdb/variables_global.py
+++ b/genegraphdb/variables_global.py
@@ -1,5 +1,4 @@
 import os
-from csv import reader
 
 exclude_directories = [".git", ".idea", "venv"]
 sql_tables = ["proteins", "samples", "crisprs", "contigs", "contig2sample", "crisprcoords", "proteincoords", "prot2prot",

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,21 @@ from setuptools import setup, find_packages
 
 setup(
     name="genegraphdb",
-    version='0.0.0_dev',
-    description='A command line tool to create and query a gene graph databases.',
-    url='https://github.com/pdhsulab/GeneGraphDB',
+    version="0.0.0_dev",
+    description="A command line tool to create and query a gene graph databases.",
+    url="https://github.com/pdhsulab/GeneGraphDB",
     author="Matt Durrant",
     author_email="mdurrant@berkeley.edu",
     license="MIT",
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'click==8.0.1',
-        'neo4j==4.3.1',
-        'pytz==2021.1',
-        'biopython==1.79',
-        'numpy==1.21.0',
+        "click==8.0.1",
+        "neo4j==4.3.1",
+        "pytz==2021.1",
+        "biopython==1.79",
+        "numpy==1.21.0",
     ],
     zip_safe=False,
-    entry_points = {
-        'console_scripts': [
-            'ggdb = genegraphdb.main:cli'
-        ]
-}
+    entry_points={"console_scripts": ["ggdb = genegraphdb.main:cli"]},
 )


### PR DESCRIPTION
This PR relies on two automated tools to clean up existing python modules.

My selfish motivation for this is that it makes the code easier to read before I dive in deeper.  The long term motivation for this is that we should have a clean codebase, before releasing it alongside our paper.

Specifically, I think we should follow PEP 8 style conventions when possible.  I also like following Google style conventions (minus their 2 space indents), because I think it's an easier convention to learn about than PEP 8.  They also do a better job of summarizing the reasoning behind their conventions.

https://google.github.io/styleguide/pyguide.html

The two tools are:

1. pycharm `optimize imports`.  This removes unused imports.  It also sorts imports into 3 stanzas at the top of every file, alphabetized per-stanza

```
stdlib import 1
stdlib import 2...

external package import 1
external package import 2...

module import 1
module import 2
```

This is in line with PEP8 style conventions: https://www.python.org/dev/peps/pep-0008/#imports

2. [black](https://github.com/psf/black) autoformatter.  specifically i'm calling `black -l 120 <filename>` to specify that the line length can be up to 120 characters.  black is an amazing tool that makes your code as PEP 8 compliant as possible, without making any breaking changes.  you can write relatively sloppy code and simply call this tool before committing, or before merging a PR.




