### PR TITLE
cloudbuild

### DIFF
--- a/developer_env/README.md
+++ b/developer_env/README.md
@@ -34,3 +34,17 @@ and consider adding this line to your .bashrc/.zshrc or similar.
 Sourcing setup.sh will also change your local git settings to automatically strip output from ipython notebooks.
 This decreases the size of files committed to github, decreases the risk that sensitive information is committed,
 and decreases the noise of commits (ipython notebook outputs can change without any code changing).
+
+
+## CloudBuild
+
+CloudBuild is a tool offered from GCP for CI/CD ("continuous integration continuous deploy").
+For the typical engineering team, this means building/compiling code, running tests, and deploying the built code to
+e.g. a web server.  For now, we're just using it to build docker images.
+
+### Building a new base image
+
+```
+git tag 'build_base' -f
+git push origin build_base -f
+```

--- a/developer_env/cloudbuild/cloudbuild_base.yaml
+++ b/developer_env/cloudbuild/cloudbuild_base.yaml
@@ -21,6 +21,7 @@ steps:
 #  args: ['pull', '${_OUTPUT_IMAGE_NAME}']
 #  id: 'pull_image'
 #  waitFor: ['-']
+# meaningless comment to trigger new build
 
 # 3. build base image
 - name: 'gcr.io/cloud-builders/docker'

--- a/developer_env/cloudbuild/cloudbuild_base.yaml
+++ b/developer_env/cloudbuild/cloudbuild_base.yaml
@@ -28,7 +28,7 @@ steps:
   args: [
           'build',
           '-t', '${_OUTPUT_IMAGE_NAME}',
-          '-t', '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}',
+#          '-t', '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}',
 #          '--cache-from', '${_OUTPUT_IMAGE_NAME}',
           'developer_env'
         ]
@@ -56,6 +56,6 @@ substitutions:
 
 images:
 - '${_OUTPUT_IMAGE_NAME}:latest'
-- '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}'
+#- '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}'
 
 timeout: '600s'

--- a/developer_env/cloudbuild/cloudbuild_base.yaml
+++ b/developer_env/cloudbuild/cloudbuild_base.yaml
@@ -1,0 +1,60 @@
+# Build base GGDB image
+steps:
+
+# 1. Move code from /workspace to /GeneGraphDB .
+# NOTE(john) I think this will be useful in future when we add tests to build pipeline
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: bash
+  args:
+  - '-c'
+  - |
+    shopt -s extglob dotglob
+    mv * /GeneGraphDB
+  volumes:
+  - name: 'GGDB'
+    path: '/GeneGraphDB'
+  id: 'move_code'
+  waitFor: ['-']
+
+## 2. pull GGDB image
+#- name: 'gcr.io/cloud-builders/docker'
+#  args: ['pull', '${_OUTPUT_IMAGE_NAME}']
+#  id: 'pull_image'
+#  waitFor: ['-']
+
+# 3. build base image
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+          'build',
+          '-t', '${_OUTPUT_IMAGE_NAME}',
+          '-t', '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}',
+#          '--cache-from', '${_OUTPUT_IMAGE_NAME}',
+          'developer_env'
+        ]
+  dir: '/GeneGraphDB'
+  volumes:
+  - name: 'GGDB'
+    path: '/GeneGraphDB'
+  id: 'build_base'
+#  waitFor: ['pull_image', 'move_code']
+
+# 4. run tests
+#- name: '${_OUTPUT_IMAGE_NAME}'
+#  args: ['pytest', './test']
+#  dir: '/GeneGraphDB'
+#  volumes:
+#  - name: 'GGDB'
+#    path: '/GeneGraphDB'
+#  id: 'test'
+#  waitFor: ['build_base']
+
+################################################## Build instructions ##################################################
+
+substitutions:
+  _OUTPUT_IMAGE_NAME: 'gcr.io/durrant/genegraphdb_base'
+
+images:
+- '${_OUTPUT_IMAGE_NAME}:latest'
+- '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}'
+
+timeout: '600s'

--- a/developer_env/cloudbuild/cloudbuild_base.yaml
+++ b/developer_env/cloudbuild/cloudbuild_base.yaml
@@ -16,20 +16,19 @@ steps:
   id: 'move_code'
   waitFor: ['-']
 
-## 2. pull GGDB image
-#- name: 'gcr.io/cloud-builders/docker'
-#  args: ['pull', '${_OUTPUT_IMAGE_NAME}']
-#  id: 'pull_image'
-#  waitFor: ['-']
-# meaningless comment to trigger new build
+# 2. pull GGDB image
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['pull', '${_OUTPUT_IMAGE_NAME}']
+  id: 'pull_image'
+  waitFor: ['-']
 
 # 3. build base image
 - name: 'gcr.io/cloud-builders/docker'
   args: [
           'build',
           '-t', '${_OUTPUT_IMAGE_NAME}',
-#          '-t', '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}',
-#          '--cache-from', '${_OUTPUT_IMAGE_NAME}',
+          '-t', '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}',
+          '--cache-from', '${_OUTPUT_IMAGE_NAME}',
           'developer_env'
         ]
   dir: '/GeneGraphDB'
@@ -37,7 +36,7 @@ steps:
   - name: 'GGDB'
     path: '/GeneGraphDB'
   id: 'build_base'
-#  waitFor: ['pull_image', 'move_code']
+  waitFor: ['pull_image', 'move_code']
 
 # 4. run tests
 #- name: '${_OUTPUT_IMAGE_NAME}'
@@ -56,6 +55,6 @@ substitutions:
 
 images:
 - '${_OUTPUT_IMAGE_NAME}:latest'
-#- '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}'
+- '${_OUTPUT_IMAGE_NAME}:${SHORT_SHA}'
 
 timeout: '600s'


### PR DESCRIPTION
introduces a yaml file giving instructions to cloudbuild.

on a push to the github tab `build_base`, a new docker image will be built from `developer_env/Dockerfile` and pushed to google container registry at `gcr.io/durrant/genegraphdb_base`